### PR TITLE
fixes title sequence manager not updating

### DIFF
--- a/memory/title_sequence_manager.py
+++ b/memory/title_sequence_manager.py
@@ -26,16 +26,16 @@ class TitleSequenceManager:
     def update(self):
         try:
             self.memory.update()
+
             if self.memory.ready_for_updates():
-                if self.base is None or self.fields_base is None:
-                    singleton_ptr = self.memory.get_singleton_by_class_name(
-                        "TitleSequenceManager"
-                    )
-                    self.base = self.memory.get_class_base(singleton_ptr)
-                    self.fields_base = self.memory.get_class_fields_base(singleton_ptr)
-                    self.title_screen = self.memory.get_field(
-                        self.fields_base, "titleScreen"
-                    )
+                singleton_ptr = self.memory.get_singleton_by_class_name(
+                    "TitleSequenceManager"
+                )
+                self.base = self.memory.get_class_base(singleton_ptr)
+                self.fields_base = self.memory.get_class_fields_base(singleton_ptr)
+                self.title_screen = self.memory.get_field(
+                    self.fields_base, "titleScreen"
+                )
 
                 # Update fields
                 self.title_position_set = False

--- a/memory/title_sequence_manager.py
+++ b/memory/title_sequence_manager.py
@@ -26,7 +26,6 @@ class TitleSequenceManager:
     def update(self):
         try:
             self.memory.update()
-
             if self.memory.ready_for_updates():
                 singleton_ptr = self.memory.get_singleton_by_class_name(
                     "TitleSequenceManager"
@@ -51,6 +50,7 @@ class TitleSequenceManager:
             else:
                 self.__init__()
         except Exception:
+            self.title_cursor_position = TitleCursorPosition.NONE
             return
 
     def get_title_cursor_position(self):


### PR DESCRIPTION
When going back to the main menu, the cursor position did not update.

This was caused by the object being unloaded. This can probably find a long term fix, but for now we'll just requery the class.