### PR TITLE
adds character select to title sequence manager

### DIFF
--- a/GUI/debug_menu.py
+++ b/GUI/debug_menu.py
@@ -41,6 +41,16 @@ class DebugMenu(Menu):
         imgui.text(
             f"Title Cursor Position: {title_cursor_position.name} ({title_cursor_position.value})"
         )
+        left_button = title_sequence_manager.character_select_left_button
+        right_button = title_sequence_manager.character_select_right_button
+        if left_button:
+            imgui.text(
+                f"Left Character: {left_button.character.value} Selected: ({left_button.selected})"
+            )
+        if right_button:
+            imgui.text(
+                f"Right Character: {right_button.character.value} Selected: ({right_button.selected})"
+            )
 
         GUI_helper.add_spacer()
 

--- a/GUI/debug_menu.py
+++ b/GUI/debug_menu.py
@@ -43,14 +43,14 @@ class DebugMenu(Menu):
         )
         left_button = title_sequence_manager.character_select_left_button
         right_button = title_sequence_manager.character_select_right_button
-        if left_button:
-            imgui.text(
-                f"Left Character: {left_button.character.value} Selected: ({left_button.selected})"
-            )
-        if right_button:
-            imgui.text(
-                f"Right Character: {right_button.character.value} Selected: ({right_button.selected})"
-            )
+
+        imgui.text(
+            f"Left Character: {left_button.character.value} Selected: ({left_button.selected})"
+        )
+
+        imgui.text(
+            f"Right Character: {right_button.character.value} Selected: ({right_button.selected})"
+        )
 
         GUI_helper.add_spacer()
 

--- a/memory/title_sequence_manager.py
+++ b/memory/title_sequence_manager.py
@@ -41,46 +41,46 @@ class TitleSequenceManager:
         )
 
     def update(self):
-        # try:
-        if self.memory.ready_for_updates:
-            if self.base is None or self.fields_base is None:
-                singleton_ptr = self.memory.get_singleton_by_class_name(
-                    "TitleSequenceManager"
-                )
+        try:
+            if self.memory.ready_for_updates:
+                if self.base is None or self.fields_base is None:
+                    singleton_ptr = self.memory.get_singleton_by_class_name(
+                        "TitleSequenceManager"
+                    )
 
-                if singleton_ptr is None:
-                    return
+                    if singleton_ptr is None:
+                        return
 
-                self.base = self.memory.get_class_base(singleton_ptr)
-                if self.base == 0x0:
-                    return
+                    self.base = self.memory.get_class_base(singleton_ptr)
+                    if self.base == 0x0:
+                        return
 
-                self.fields_base = self.memory.get_class_fields_base(singleton_ptr)
-                self.title_screen = self.memory.get_field(
-                    self.fields_base, "titleScreen"
-                )
-                self.character_selection_screen = self.memory.get_field(
-                    self.fields_base, "characterSelectionScreen"
-                )
-            else:
-                # Update fields
-                self.title_position_set = False
-                self._read_load_save_done()
-                self._read_new_game_characters()
-                self._read_pressed_start()
-                self._read_continue_selected()
-                self._read_new_game_selected()
-                self._read_new_game_plus_selected()
-                self._read_load_game_selected()
-                self._read_options_selected()
-                self._read_quit_selected()
+                    self.fields_base = self.memory.get_class_fields_base(singleton_ptr)
+                    self.title_screen = self.memory.get_field(
+                        self.fields_base, "titleScreen"
+                    )
+                    self.character_selection_screen = self.memory.get_field(
+                        self.fields_base, "characterSelectionScreen"
+                    )
+                else:
+                    # Update fields
+                    self.title_position_set = False
+                    self._read_load_save_done()
+                    self._read_new_game_characters()
+                    self._read_pressed_start()
+                    self._read_continue_selected()
+                    self._read_new_game_selected()
+                    self._read_new_game_plus_selected()
+                    self._read_load_game_selected()
+                    self._read_options_selected()
+                    self._read_quit_selected()
 
-            if not self.title_position_set:
-                self.title_cursor_position = TitleCursorPosition.NONE
+                if not self.title_position_set:
+                    self.title_cursor_position = TitleCursorPosition.NONE
 
-    # except Exception as _e:  # noqa: F841
-    #     # logger.debug(f"Title Sequence Manager Reloading {type(_e)}")
-    #     self.__init__()
+        except Exception as _e:  # noqa: F841
+            # logger.debug(f"Title Sequence Manager Reloading {type(_e)}")
+            self.__init__()
 
     def _read_new_game_characters(self):
         try:

--- a/memory/title_sequence_manager.py
+++ b/memory/title_sequence_manager.py
@@ -41,100 +41,109 @@ class TitleSequenceManager:
         )
 
     def update(self):
-        try:
-            if self.memory.ready_for_updates:
-                if self.base is None or self.fields_base is None:
-                    singleton_ptr = self.memory.get_singleton_by_class_name(
-                        "TitleSequenceManager"
-                    )
+        # try:
+        if self.memory.ready_for_updates:
+            if self.base is None or self.fields_base is None:
+                singleton_ptr = self.memory.get_singleton_by_class_name(
+                    "TitleSequenceManager"
+                )
 
-                    if singleton_ptr is None:
-                        return
+                if singleton_ptr is None:
+                    return
 
-                    self.base = self.memory.get_class_base(singleton_ptr)
-                    if self.base == 0x0:
-                        return
+                self.base = self.memory.get_class_base(singleton_ptr)
+                if self.base == 0x0:
+                    return
 
-                    self.fields_base = self.memory.get_class_fields_base(singleton_ptr)
-                    self.title_screen = self.memory.get_field(
-                        self.fields_base, "titleScreen"
-                    )
-                    self.character_selection_screen = self.memory.get_field(
-                        self.fields_base, "characterSelectionScreen"
-                    )
-                else:
-                    # Update fields
-                    self.title_position_set = False
-                    self._read_load_save_done()
-                    self._read_new_game_characters()
-                    self._read_pressed_start()
-                    self._read_continue_selected()
-                    self._read_new_game_selected()
-                    self._read_new_game_plus_selected()
-                    self._read_load_game_selected()
-                    self._read_options_selected()
-                    self._read_quit_selected()
+                self.fields_base = self.memory.get_class_fields_base(singleton_ptr)
+                self.title_screen = self.memory.get_field(
+                    self.fields_base, "titleScreen"
+                )
+                self.character_selection_screen = self.memory.get_field(
+                    self.fields_base, "characterSelectionScreen"
+                )
+            else:
+                # Update fields
+                self.title_position_set = False
+                self._read_load_save_done()
+                self._read_new_game_characters()
+                self._read_pressed_start()
+                self._read_continue_selected()
+                self._read_new_game_selected()
+                self._read_new_game_plus_selected()
+                self._read_load_game_selected()
+                self._read_options_selected()
+                self._read_quit_selected()
 
-                if not self.title_position_set:
-                    self.title_cursor_position = TitleCursorPosition.NONE
+            if not self.title_position_set:
+                self.title_cursor_position = TitleCursorPosition.NONE
 
-        except Exception as _e:  # noqa: F841
-            # logger.debug(f"Title Sequence Manager Reloading {type(_e)}")
-            self.__init__()
+    # except Exception as _e:  # noqa: F841
+    #     # logger.debug(f"Title Sequence Manager Reloading {type(_e)}")
+    #     self.__init__()
 
     def _read_new_game_characters(self):
-        # characterSelectionScreen -> leftButton -> characterDefinitionId
-        left_button_character_definition_id_ptr = self.memory.follow_pointer(
-            self.base, [self.character_selection_screen, 0xD8, 0x18, 0x0]
-        )
-        left_character_value = self.memory.read_string(
-            left_button_character_definition_id_ptr + 0x14, 8
-        )
-        left_character = PlayerPartyCharacter.parse_definition_id(left_character_value)
+        try:
+            # characterSelectionScreen -> leftButton -> characterDefinitionId
+            left_button_character_definition_id_ptr = self.memory.follow_pointer(
+                self.base, [self.character_selection_screen, 0xD8, 0x18, 0x0]
+            )
+            left_character_value = self.memory.read_string(
+                left_button_character_definition_id_ptr + 0x14, 8
+            )
+            left_character = PlayerPartyCharacter.parse_definition_id(
+                left_character_value
+            )
 
-        # characterSelectionScreen -> leftButton -> selected
-        left_button_selected_ptr = self.memory.follow_pointer(
-            self.base, [self.character_selection_screen, 0xD8, 0x0]
-        )
-        left_character_selected = self.memory.read_bool(left_button_selected_ptr + 0x60)
+            # characterSelectionScreen -> rightButton -> characterDefinitionId
+            right_button_character_definition_id_ptr = self.memory.follow_pointer(
+                self.base, [self.character_selection_screen, 0xE0, 0x18, 0x0]
+            )
+            right_character_value = self.memory.read_string(
+                right_button_character_definition_id_ptr + 0x14, 8
+            )
+            right_character = PlayerPartyCharacter.parse_definition_id(
+                right_character_value
+            )
+        except Exception:
+            right_character = None
+            left_character = None
 
-        # characterSelectionScreen -> rightButton -> characterDefinitionId
-        right_button_character_definition_id_ptr = self.memory.follow_pointer(
-            self.base, [self.character_selection_screen, 0xE0, 0x18, 0x0]
-        )
-        right_button_selected_ptr = self.memory.follow_pointer(
-            self.base, [self.character_selection_screen, 0xE0, 0x0]
-        )
-
-        # characterSelectionScreen -> rightButton -> selected
-        right_character_selected = self.memory.read_bool(
-            right_button_selected_ptr + 0x60
-        )
-        right_character_value = self.memory.read_string(
-            right_button_character_definition_id_ptr + 0x14, 8
-        )
-        right_character = PlayerPartyCharacter.parse_definition_id(
-            right_character_value
-        )
-
-        # Corrects the weird scenario where both sides can be true when you're in the middle
-        # of two results. It makes the value more reasonable to consume.
-        right_selected = (
-            False
-            if right_character_selected == left_character_selected
-            else right_character_selected
-        )
-        left_selected = (
-            False
-            if right_character_selected == left_character_selected
-            else left_character_selected
-        )
-        self.character_select_right_button = CharacterSelectButton(
-            right_character, right_selected
-        )
-        self.character_select_left_button = CharacterSelectButton(
-            left_character, left_selected
-        )
+        try:
+            selected_character_pointer = self.memory.follow_pointer(
+                self.base, [self.character_selection_screen, 0xE8, 0x0]
+            )
+            selected_character_value = self.memory.read_bool(
+                selected_character_pointer + 0x60
+            )
+            selected_character = None
+            match selected_character_value:
+                case False:
+                    selected_character = left_character
+                case True:
+                    selected_character = right_character
+                case _:
+                    selected_character = None
+        except Exception:
+            selected_character = PlayerPartyCharacter.NONE
+        try:
+            # Corrects the weird scenario where both sides can be true when you're in the middle
+            # of two results. It makes the value more reasonable to consume.
+            right_selected = right_character == selected_character
+            left_selected = left_character == selected_character
+            self.character_select_right_button = CharacterSelectButton(
+                right_character, right_selected
+            )
+            self.character_select_left_button = CharacterSelectButton(
+                left_character, left_selected
+            )
+        except Exception:
+            self.character_select_left_button = CharacterSelectButton(
+                PlayerPartyCharacter.NONE, False
+            )
+            self.character_select_right_button = CharacterSelectButton(
+                PlayerPartyCharacter.NONE, False
+            )
 
     def _read_continue_selected(self):
         # titleScreen -> continueButton -> selected

--- a/memory/title_sequence_manager.py
+++ b/memory/title_sequence_manager.py
@@ -1,6 +1,7 @@
 from enum import Enum, auto
 
 from memory.core import mem_handle
+from memory.mappers.player_party_character import PlayerPartyCharacter
 
 
 class TitleCursorPosition(Enum):
@@ -13,56 +14,112 @@ class TitleCursorPosition(Enum):
     Quit = auto()
 
 
+class CharacterSelectButton:
+    def __init__(self, character: PlayerPartyCharacter, selected: bool):
+        self.character = character
+        self.selected = selected
+
+
 class TitleSequenceManager:
     def __init__(self):
         self.memory = mem_handle()
         self.base = None
         self.fields_base = None
         self.title_screen = None
+        self.character_selection_screen = None
         # True if there was a save to load and the continue button shows up
         self.load_save_done = False
         # True if you pressed start on the "press start" screen before the title menu shows up
         self.pressed_start = False
         self.title_cursor_position = TitleCursorPosition.NONE
         self.title_position_set = False
+        self.character_select_left_button = CharacterSelectButton(
+            PlayerPartyCharacter.NONE, False
+        )
+        self.character_select_right_button = CharacterSelectButton(
+            PlayerPartyCharacter.NONE, False
+        )
 
     def update(self):
-        try:
-            if self.memory.ready_for_updates:
-                if self.base is None or self.fields_base is None:
-                    singleton_ptr = self.memory.get_singleton_by_class_name(
-                        "TitleSequenceManager"
-                    )
+        # try:
+        if self.memory.ready_for_updates:
+            if self.base is None or self.fields_base is None:
+                singleton_ptr = self.memory.get_singleton_by_class_name(
+                    "TitleSequenceManager"
+                )
 
-                    if singleton_ptr is None:
-                        return
+                if singleton_ptr is None:
+                    return
 
-                    self.base = self.memory.get_class_base(singleton_ptr)
+                self.base = self.memory.get_class_base(singleton_ptr)
+                if self.base == 0x0:
+                    return
 
-                    if self.base == 0x0:
-                        return
+                self.fields_base = self.memory.get_class_fields_base(singleton_ptr)
+                self.title_screen = self.memory.get_field(
+                    self.fields_base, "titleScreen"
+                )
+                self.character_selection_screen = self.memory.get_field(
+                    self.fields_base, "characterSelectionScreen"
+                )
+            else:
+                # Update fields
+                self.title_position_set = False
+                self._read_load_save_done()
+                self._read_new_game_characters()
+                self._read_pressed_start()
+                self._read_continue_selected()
+                self._read_new_game_selected()
+                self._read_new_game_plus_selected()
+                self._read_load_game_selected()
+                self._read_options_selected()
+                self._read_quit_selected()
 
-                    self.fields_base = self.memory.get_class_fields_base(singleton_ptr)
-                    self.title_screen = self.memory.get_field(
-                        self.fields_base, "titleScreen"
-                    )
-                else:
-                    # Update fields
-                    self.title_position_set = False
-                    self._read_load_save_done()
-                    self._read_pressed_start()
-                    self._read_continue_selected()
-                    self._read_new_game_selected()
-                    self._read_new_game_plus_selected()
-                    self._read_load_game_selected()
-                    self._read_options_selected()
-                    self._read_quit_selected()
+            if not self.title_position_set:
+                self.title_cursor_position = TitleCursorPosition.NONE
 
-                if not self.title_position_set:
-                    self.title_cursor_position = TitleCursorPosition.NONE
-        except Exception as _e:  # noqa: F841
-            # logger.debug(f"Title Sequence Manager Reloading {type(_e)}")
-            self.__init__()
+    # except Exception as _e:  # noqa: F841
+    #     # logger.debug(f"Title Sequence Manager Reloading {type(_e)}")
+    #     self.__init__()
+
+    def _read_new_game_characters(self):
+        # titleScreen -> continueButton -> selected
+        left_button_character_definition_id_ptr = self.memory.follow_pointer(
+            self.base, [self.character_selection_screen, 0xD8, 0x18, 0x0]
+        )
+
+        left_character_value = self.memory.read_string(
+            left_button_character_definition_id_ptr + 0x14, 8
+        )
+        left_character = PlayerPartyCharacter.parse_definition_id(left_character_value)
+
+        left_button_selected_ptr = self.memory.follow_pointer(
+            self.base, [self.character_selection_screen, 0xD8, 0x0]
+        )
+        left_character_selected = self.memory.read_bool(left_button_selected_ptr + 0x60)
+
+        right_button_character_definition_id_ptr = self.memory.follow_pointer(
+            self.base, [self.character_selection_screen, 0xE0, 0x18, 0x0]
+        )
+        right_button_selected_ptr = self.memory.follow_pointer(
+            self.base, [self.character_selection_screen, 0xE0, 0x0]
+        )
+        right_character_selected = self.memory.read_bool(
+            right_button_selected_ptr + 0x60
+        )
+        right_character_value = self.memory.read_string(
+            right_button_character_definition_id_ptr + 0x14, 8
+        )
+        right_character = PlayerPartyCharacter.parse_definition_id(
+            right_character_value
+        )
+
+        self.character_select_right_button = CharacterSelectButton(
+            right_character, right_character_selected
+        )
+        self.character_select_left_button = CharacterSelectButton(
+            left_character, left_character_selected
+        )
 
     def _read_continue_selected(self):
         # titleScreen -> continueButton -> selected


### PR DESCRIPTION
closes #68

Notes:
- both are considered selected when neither is selected. This is corrected by checking double True and making it false
- both are considered non-selected after selecting character or returning to main menu
- this correctly tracks sides if you go back to main menu and back to character select