### PR TITLE
Moved imports to use "memory" instead of "memory.player_party_manager, memory.title_manager", etc.

### DIFF
--- a/GUI/GUI.py
+++ b/GUI/GUI.py
@@ -6,12 +6,14 @@ import imgui
 import OpenGL.GL as gl
 from imgui.integrations.glfw import GlfwRenderer
 
-from memory.boat_manager import boat_manager_handle
-from memory.combat_manager import combat_manager_handle
-from memory.core import mem_handle
-from memory.level_manager import level_manager_handle
-from memory.player_party_manager import player_party_manager_handle
-from memory.title_sequence_manager import title_sequence_manager_handle
+from memory import (
+    boat_manager_handle,
+    combat_manager_handle,
+    level_manager_handle,
+    mem_handle,
+    player_party_manager_handle,
+    title_sequence_manager_handle,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/GUI/battle_menu.py
+++ b/GUI/battle_menu.py
@@ -4,7 +4,7 @@ import imgui
 
 from GUI.GUI import Window
 from GUI.menu import Menu
-from memory.combat_manager import combat_manager_handle
+from memory import combat_manager_handle
 
 logger = logging.getLogger(__name__)
 

--- a/GUI/debug_menu.py
+++ b/GUI/debug_menu.py
@@ -4,9 +4,11 @@ import imgui
 
 from GUI.GUI import GUI_helper, Window
 from GUI.menu import Menu
-from memory.level_manager import level_manager_handle
-from memory.player_party_manager import player_party_manager_handle
-from memory.title_sequence_manager import title_sequence_manager_handle
+from memory import (
+    level_manager_handle,
+    player_party_manager_handle,
+    title_sequence_manager_handle,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/GUI/tools/nav_helper.py
+++ b/GUI/tools/nav_helper.py
@@ -8,9 +8,11 @@ from engine.mathlib import Quaternion, Vec2, Vec3
 from engine.seq.move import move_to
 from GUI.GUI import GUI_helper, Window
 from GUI.menu import Menu
-from memory.boat_manager import boat_manager_handle
-from memory.player_party_manager import player_party_manager_handle
-from memory.title_sequence_manager import title_sequence_manager_handle
+from memory import (
+    boat_manager_handle,
+    player_party_manager_handle,
+    title_sequence_manager_handle,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/engine/combat/appraisals/basic_attack.py
+++ b/engine/combat/appraisals/basic_attack.py
@@ -2,8 +2,7 @@ import logging
 
 from control import sos_ctrl
 from engine.combat.utility.sos_appraisal import SoSAppraisal, SoSAppraisalType
-from memory.combat_manager import combat_manager_handle
-from memory.mappers.player_party_character import PlayerPartyCharacter
+from memory import PlayerPartyCharacter, combat_manager_handle
 
 logger = logging.getLogger(__name__)
 

--- a/engine/combat/combat_and_move.py
+++ b/engine/combat/combat_and_move.py
@@ -4,7 +4,7 @@ from control.sos import sos_ctrl
 from engine.combat.combat_controller import CombatController
 from engine.mathlib import Vec3
 from engine.seq.move import HoldDirection, InteractMove, SeqMove
-from memory.combat_manager import combat_manager_handle
+from memory import combat_manager_handle
 
 combat_manager = combat_manager_handle()
 

--- a/engine/combat/combat_controller.py
+++ b/engine/combat/combat_controller.py
@@ -1,7 +1,6 @@
 from control import sos_ctrl
 from engine.combat.utility.sos_reasoner import SoSReasoner
-from memory.combat_manager import combat_manager_handle
-from memory.mappers.player_party_character import PlayerPartyCharacter
+from memory import PlayerPartyCharacter, combat_manager_handle
 
 combat_manager = combat_manager_handle()
 

--- a/engine/combat/manual.py
+++ b/engine/combat/manual.py
@@ -3,7 +3,7 @@ from collections.abc import Callable
 from control import sos_ctrl
 from engine.mathlib import Vec3
 from engine.seq.move import HoldDirection, InteractMove, SeqMove
-from memory.combat_manager import combat_manager_handle
+from memory import combat_manager_handle
 
 combat_manager = combat_manager_handle()
 

--- a/engine/combat/utility/core/action.py
+++ b/engine/combat/utility/core/action.py
@@ -4,9 +4,11 @@
 # The consideration will execute to setup for the action, and
 # then the appraisal will execute.
 
+from engine.combat.utility.core.appraisal import Appraisal
+
 
 class Action:
-    def __init__(self, consideration, appraisal):
+    def __init__(self, consideration, appraisal: Appraisal):
         self.consideration = consideration
         self.appraisal = appraisal
 

--- a/engine/combat/utility/sos_consideration.py
+++ b/engine/combat/utility/sos_consideration.py
@@ -3,7 +3,7 @@ from engine.combat.appraisals.basic_attack import BasicAttack
 from engine.combat.utility.core.action import Action
 from engine.combat.utility.core.appraisal import Appraisal
 from engine.combat.utility.core.consideration import Consideration
-from memory.mappers.player_party_character import PlayerPartyCharacter
+from memory import PlayerPartyCharacter
 
 
 class SoSConsideration(Consideration):

--- a/engine/combat/utility/sos_reasoner.py
+++ b/engine/combat/utility/sos_reasoner.py
@@ -2,7 +2,7 @@ from engine.combat.utility.core.action import Action
 from engine.combat.utility.core.consideration import Consideration
 from engine.combat.utility.core.reasoner import Reasoner
 from engine.combat.utility.sos_consideration import SoSConsideration
-from memory.combat_manager import CombatPlayer
+from memory import CombatPlayer
 
 
 class SoSReasoner(Reasoner):

--- a/engine/seq/amulet.py
+++ b/engine/seq/amulet.py
@@ -3,10 +3,8 @@ import time
 
 from control import sos_ctrl
 from engine.seq.base import SeqBase
-from memory.combat_manager import combat_manager_handle
 
 logger = logging.getLogger(__name__)
-combat_manager = combat_manager_handle()
 
 
 # TODO: Temporary code, moves along path, pausing while combat is active

--- a/engine/seq/interact.py
+++ b/engine/seq/interact.py
@@ -2,7 +2,7 @@
 
 from control import sos_ctrl
 from engine.seq.base import SeqBase
-from memory.player_party_manager import PlayerMovementState, player_party_manager_handle
+from memory import PlayerMovementState, player_party_manager_handle
 
 player_party_manager = player_party_manager_handle()
 

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -1,5 +1,26 @@
-from memory.core import SoSMemory
+from memory.boat_manager import boat_manager_handle
+from memory.combat_manager import CombatPlayer, combat_manager_handle
+from memory.core import SoSMemory, mem_handle
+from memory.level_manager import level_manager_handle
+from memory.mappers.enemy_name import EnemyName
+from memory.mappers.player_party_character import PlayerPartyCharacter
+from memory.player_party_manager import PlayerMovementState, player_party_manager_handle
+from memory.title_sequence_manager import (
+    TitleCursorPosition,
+    title_sequence_manager_handle,
+)
 
 __all__ = [
     "SoSMemory",
+    "mem_handle",
+    "boat_manager_handle",
+    "combat_manager_handle",
+    "level_manager_handle",
+    "player_party_manager_handle",
+    "title_sequence_manager_handle",
+    "PlayerPartyCharacter",
+    "PlayerMovementState",
+    "TitleCursorPosition",
+    "EnemyName",
+    "CombatPlayer",
 ]

--- a/route/evermist_island/intro.py
+++ b/route/evermist_island/intro.py
@@ -18,7 +18,7 @@ from engine.seq import (
     SeqTurboMashSkipCutsceneUntilIdle,
     SeqTurboMashUntilIdle,
 )
-from memory.player_party_manager import (
+from memory import (
     PlayerPartyCharacter,
     player_party_manager_handle,
 )

--- a/route/start.py
+++ b/route/start.py
@@ -12,7 +12,7 @@ from engine.seq import (
     SeqLog,
 )
 from log_init import reset_logging_time_reference
-from memory.title_sequence_manager import (
+from memory import (
     TitleCursorPosition,
     title_sequence_manager_handle,
 )


### PR DESCRIPTION
Mostly to clean up files where they are imported.