### PR TITLE
Minor Start TAS GUI improvement

### DIFF
--- a/route/TAS.py
+++ b/route/TAS.py
@@ -104,8 +104,6 @@ class TASMenu(Menu):
             )
 
             if self.load_game_checkbox:
-                # TODO(orkaboy): Maybe should check for valid range 1-9
-                _, self.saveslot = imgui.input_int("Save slot 1-9", self.saveslot)
                 # TODO(orkaboy): Maybe should be a dropdown of valid checkpoints
                 _, self.checkpoint = imgui.input_text(
                     "Checkpoint name", self.checkpoint
@@ -127,11 +125,24 @@ class TASMenu(Menu):
             _, self.run_start_sequence = imgui.checkbox(
                 "Should run start sequence", self.run_start_sequence
             )
+            if self.run_start_sequence and self.load_game_checkbox:
+                # TODO(orkaboy): Maybe should check for valid range 1-9
+                _, self.saveslot = imgui.input_int("Save slot 1-9", self.saveslot)
+                LayoutHelper.add_tooltip(
+                    "Save slot 1-9 is valid, mapping to the in-game slot\n"
+                    + "that holds the checkpoint save."
+                )
 
             self.custom_gui()
 
             if imgui.button("Start TAS"):
-                saveslot = self.saveslot if self.load_game_checkbox else 0
+                # Only set saveslot if loading from main menu
+                saveslot = (
+                    self.saveslot
+                    if (self.load_game_checkbox and self.run_start_sequence)
+                    else 0
+                )
+
                 if self.run_start_sequence:
                     self.init_start_sequence(saveslot)
                 self.init_TAS()

--- a/route/TAS.py
+++ b/route/TAS.py
@@ -63,9 +63,9 @@ class TASMenu(Menu):
             root=SeqLog(name="SYSTEM", text="ERROR, NO TAS SEQUENCE!"),
         )
 
-    def init_saveslot(self: Self, saveslot: int) -> None:
+    def init_saveslot(self: Self) -> None:
         """Potentially advance the TAS to a particular checkpoint."""
-        if saveslot == 0:
+        if not self.load_game_checkbox:
             logger.info("Starting TAS from the beginning")
         elif self.sequencer.advance_to_checkpoint(checkpoint=self.checkpoint):
             logger.info(f"Advanced TAS to checkpoint '{self.checkpoint}'")
@@ -146,7 +146,7 @@ class TASMenu(Menu):
                 if self.run_start_sequence:
                     self.init_start_sequence(saveslot)
                 self.init_TAS()
-                self.init_saveslot(saveslot)
+                self.init_saveslot()
                 self.tas_is_running = True
 
             if not top_level and imgui.button("Back"):


### PR DESCRIPTION
Fixed a bug, and improved on the start TAS GUI. It only shows (and accounts for) the `saveslot` field if the `run_start_sequence` checkbox is checked.