### PR TITLE
Refactors Combat Controllers

### DIFF
--- a/control/sos.py
+++ b/control/sos.py
@@ -103,6 +103,9 @@ class SoSController:
     def toggle_confirm(self: Self, state: bool) -> None:
         self.set_button(x_key=Buttons.CONFIRM, value=1 if state else 0)
 
+    def toggle_boost(self: Self, state: bool) -> None:
+        self.set_button(x_key=VgButtons.TRIG_R, value=1 if state else 0)
+
     def toggle_graplou(self: Self, state: bool) -> None:
         self.set_button(x_key=Buttons.GRAPLOU, value=1 if state else 0)
 

--- a/engine/combat/appraisals/basic_attack.py
+++ b/engine/combat/appraisals/basic_attack.py
@@ -15,8 +15,6 @@ class BasicAttack(SoSAppraisal):
     def __init__(
         self: Self, timing_type: SoSTimingType = SoSTimingType.OneHit, boost: int = 0
     ) -> None:
-        super().__init__()
-        self.timing_type = timing_type
+        super().__init__(boost=boost, timing_type=timing_type)
         self.battle_command = SoSBattleCommand.Attack
         self.target_type = SoSTargetType.Enemy
-        self.boost = boost

--- a/engine/combat/appraisals/basic_attack.py
+++ b/engine/combat/appraisals/basic_attack.py
@@ -12,8 +12,11 @@ logger = logging.getLogger(__name__)
 
 
 class BasicAttack(SoSAppraisal):
-    def __init__(self: Self, timing_type: SoSTimingType = SoSTimingType.OneHit) -> None:
+    def __init__(
+        self: Self, timing_type: SoSTimingType = SoSTimingType.OneHit, boost: int = 0
+    ) -> None:
         super().__init__()
         self.timing_type = timing_type
         self.battle_command = SoSBattleCommand.Attack
         self.target_type = SoSTargetType.Enemy
+        self.boost = boost

--- a/engine/combat/appraisals/valere/crescent_arc.py
+++ b/engine/combat/appraisals/valere/crescent_arc.py
@@ -19,9 +19,8 @@ class CrescentArc(SoSAppraisal):
         timing_type: SoSTimingType = SoSTimingType.OneHit,
         boost: int = 0,
     ) -> None:
-        super().__init__()
+        super().__init__(boost=boost, timing_type=timing_type)
         self.value = value
-        self.timing_type = timing_type
         self.battle_command = SoSBattleCommand.Skill
         self.target_type = SoSTargetType.Enemy
         # this needs to move to a system that tracks available abilities.
@@ -29,4 +28,3 @@ class CrescentArc(SoSAppraisal):
         self.skill_command_index = 0
         self.resource = SoSResource.Mana
         self.cost = 6
-        self.boost = boost

--- a/engine/combat/appraisals/valere/crescent_arc.py
+++ b/engine/combat/appraisals/valere/crescent_arc.py
@@ -14,7 +14,10 @@ logger = logging.getLogger(__name__)
 
 class CrescentArc(SoSAppraisal):
     def __init__(
-        self: Self, value: int = 0, timing_type: SoSTimingType = SoSTimingType.OneHit
+        self: Self,
+        value: int = 0,
+        timing_type: SoSTimingType = SoSTimingType.OneHit,
+        boost: int = 0,
     ) -> None:
         super().__init__()
         self.value = value
@@ -26,3 +29,4 @@ class CrescentArc(SoSAppraisal):
         self.skill_command_index = 0
         self.resource = SoSResource.Mana
         self.cost = 6
+        self.boost = boost

--- a/engine/combat/appraisals/valere/moonerang.py
+++ b/engine/combat/appraisals/valere/moonerang.py
@@ -25,9 +25,8 @@ class Moonerang(SoSAppraisal):
         timing_type: SoSTimingType = SoSTimingType.MultiHit,
         boost: int = 0,
     ) -> None:
-        super().__init__()
+        super().__init__(boost=boost, timing_type=timing_type)
         self.value = value
-        self.timing_type = timing_type
         self.battle_command = SoSBattleCommand.Skill
         self.target_type = SoSTargetType.Enemy
         # this needs to move to a system that tracks available abilities.
@@ -36,7 +35,6 @@ class Moonerang(SoSAppraisal):
         self.instruction_done = False
         self.resource = SoSResource.Mana
         self.cost = 7
-        self.boost = boost
 
     def execute_timing_sequence(self: Self) -> None:
         if self.instruction_done is False:

--- a/engine/combat/appraisals/valere/moonerang.py
+++ b/engine/combat/appraisals/valere/moonerang.py
@@ -20,7 +20,10 @@ class Moonerang(SoSAppraisal):
     HIT_AT_POSITION_VALUE = 0.50
 
     def __init__(
-        self: Self, value: int = 0, timing_type: SoSTimingType = SoSTimingType.MultiHit
+        self: Self,
+        value: int = 0,
+        timing_type: SoSTimingType = SoSTimingType.MultiHit,
+        boost: int = 0,
     ) -> None:
         super().__init__()
         self.value = value
@@ -33,6 +36,7 @@ class Moonerang(SoSAppraisal):
         self.instruction_done = False
         self.resource = SoSResource.Mana
         self.cost = 7
+        self.boost = boost
 
     def execute_timing_sequence(self: Self) -> None:
         if self.instruction_done is False:

--- a/engine/combat/appraisals/zale/sunball.py
+++ b/engine/combat/appraisals/zale/sunball.py
@@ -21,6 +21,7 @@ class Sunball(SoSAppraisal):
         value: int = 0,
         hold_time: float = 4.0,
         timing_type: SoSTimingType = SoSTimingType.Charge,
+        boost: int = 0,
     ) -> None:
         super().__init__()
         self.value = value
@@ -35,6 +36,7 @@ class Sunball(SoSAppraisal):
         self.resource = SoSResource.Mana
         self.hold_time = hold_time
         self.cost = 8  # add modifier for mana cost reduction?
+        self.boost = boost
 
     def execute_timing_sequence(self: Self) -> None:
         if self.ability_time is None:

--- a/engine/combat/appraisals/zale/sunball.py
+++ b/engine/combat/appraisals/zale/sunball.py
@@ -23,9 +23,8 @@ class Sunball(SoSAppraisal):
         timing_type: SoSTimingType = SoSTimingType.Charge,
         boost: int = 0,
     ) -> None:
-        super().__init__()
+        super().__init__(boost=boost, timing_type=timing_type)
         self.value = value
-        self.timing_type = timing_type
         self.battle_command = SoSBattleCommand.Skill
         self.target_type = SoSTargetType.Enemy
         # this needs to move to a system that tracks available abilities.
@@ -36,7 +35,6 @@ class Sunball(SoSAppraisal):
         self.resource = SoSResource.Mana
         self.hold_time = hold_time
         self.cost = 8  # add modifier for mana cost reduction?
-        self.boost = boost
 
     def execute_timing_sequence(self: Self) -> None:
         if self.ability_time is None:

--- a/engine/combat/combat_controller.py
+++ b/engine/combat/combat_controller.py
@@ -37,7 +37,6 @@ class CombatController:
             or self.controller.__class__.__name__
             is not self._encounter_controller_factory().__class__.__name__
         ):
-            # TODO(eein): Add a battle controller factory
             logger.debug("Setting New Combat Controller")
             self.controller = self._encounter_controller_factory()
             logger.debug(f"Using: {self.controller.__class__.__name__}")

--- a/engine/combat/controllers/__init__.py
+++ b/engine/combat/controllers/__init__.py
@@ -1,0 +1,17 @@
+from engine.combat.controllers.encounter_controller import EncounterController
+from engine.combat.controllers.first_encounter_controller import (
+    FirstEncounterController,
+)
+from engine.combat.controllers.live_mana_tutorial_controller import (
+    LiveManaTutorialController,
+)
+from engine.combat.controllers.second_encounter_controller import (
+    SecondEncounterController,
+)
+
+__all__ = [
+    "EncounterController",
+    "FirstEncounterController",
+    "SecondEncounterController",
+    "LiveManaTutorialController",
+]

--- a/engine/combat/controllers/encounter_controller.py
+++ b/engine/combat/controllers/encounter_controller.py
@@ -1,0 +1,119 @@
+import logging
+from typing import Self
+
+from control import sos_ctrl
+from engine.combat.utility.core.action import Action
+from engine.combat.utility.sos_reasoner import SoSReasoner
+from memory import (
+    NextCombatAction,
+    PlayerPartyCharacter,
+    combat_manager_handle,
+    level_manager_handle,
+    new_dialog_manager_handle,
+)
+
+logger = logging.getLogger(__name__)
+level_manager = level_manager_handle()
+combat_manager = combat_manager_handle()
+new_dialog_manager = new_dialog_manager_handle()
+
+
+# The classes in encounter controllers are intended to return True if they
+# should short circuit the root combat controller.
+class EncounterController:
+    def __init__(self: Self) -> None:
+        self.reasoner = SoSReasoner()
+        self.action: Action = None
+        self.block_timing = 0.0
+
+    # if combat is done, just exit
+    def encounter_done(self: Self) -> bool:
+        if combat_manager.encounter_done is True:
+            return True
+        return False
+
+    # If some dialog is on the screen - make it go away by mashing confirm
+    # There are some fights with dialog mid-fight and this will get us through it
+    # until we regain control
+    def execute_dialog(self: Self) -> bool:
+        if new_dialog_manager.dialog_open:
+            sos_ctrl().toggle_turbo(True)
+            sos_ctrl().confirm()
+            sos_ctrl().toggle_turbo(False)
+            return True
+        return False
+
+    # If we dont have an action or the current appraisal is complete,
+    # we make a new one.
+    # we also check if battle command has focus, so it doesn't start executing before
+    # we have control
+    def generate_action(self: Self) -> bool:
+        if (
+            (self.action is None or self.action.appraisal.complete)
+            and combat_manager.selected_character is not PlayerPartyCharacter.NONE
+            and combat_manager.battle_command_has_focus
+        ):
+            logger.debug("No action exists, executing one one")
+            self.action = self.reasoner.execute()
+            return True
+        return False
+
+    # Handles block execution - code is commented out until we have a better
+    # solution for blocking.
+    # Currently it will spam confirm to block.
+    def execute_block(self: Self) -> bool:
+        if (
+            self.action is None or self.action.appraisal.complete
+        ) and combat_manager.selected_character is PlayerPartyCharacter.NONE:
+            combat_manager.read_next_combat_enemy()
+            next_combat_enemy = combat_manager.next_combat_enemy
+            if (
+                next_combat_enemy
+                and next_combat_enemy.movement_done is True
+                and next_combat_enemy.state_type is NextCombatAction.Attacking
+            ):
+                logger.debug(f"Spam Block for {next_combat_enemy.move_name} Attack")
+                sos_ctrl().confirm()
+            elif (
+                next_combat_enemy
+                and next_combat_enemy.state_type is NextCombatAction.Casting
+            ):
+                logger.debug(f"Spam Block for {next_combat_enemy.move_name} Casting")
+                sos_ctrl().confirm()
+
+                return True
+        return False
+
+    # If the consideration doesn't believe the situation is valid, execute changing
+    # the selected consideration (character). This will rotate the cursor to the next
+    # available consideration until it finds the one it expects.
+    # TODO(eein): This should also take into considerations swapping characters into
+    # the game field.
+    def execute_consideration(self: Self) -> bool:
+        if not self._consideration_valid():
+            logger.debug("Consideration is not valid, move cursor")
+            self.action.consideration.execute()
+            return True
+        return False
+
+    # Executes the appraisal of the action. If the appraisal completes its lifecycle
+    # it will set self.action to None so that a new action can be generated.
+    def execute_appraisal(self: Self) -> bool:
+        self.action.appraisal.execute()
+        if self.action.appraisal.complete:
+            # logger.debug("Appraisal is complete, reset action")
+            self.action = None
+            return True
+        return False
+
+    # Checks if an action has been assigned by utility and returns true if so
+    # If there is no action to act on, it should be unable to continue with
+    # attempting to take control and attack an enemy.
+    def has_action(self: Self) -> bool:
+        return self.action is not None
+
+    # Check the consideration to see if it's valid and return true if so.
+    def _consideration_valid(self: Self) -> bool:
+        return self.action.consideration.valid(
+            combat_manager.selected_character, self.action
+        )

--- a/engine/combat/controllers/first_encounter_controller.py
+++ b/engine/combat/controllers/first_encounter_controller.py
@@ -17,11 +17,7 @@ combat_manager = combat_manager_handle()
 
 class FirstEncounterController(EncounterController):
     def generate_action(self: Self) -> bool:
-        if (
-            (self.action is None or self.action.appraisal.complete)
-            and combat_manager.selected_character is not PlayerPartyCharacter.NONE
-            and combat_manager.battle_command_has_focus
-        ):
+        if self._should_generate_action():
             logger.debug("No action exists, executing one one")
             self.action = self._get_action()
             return True

--- a/engine/combat/controllers/first_encounter_controller.py
+++ b/engine/combat/controllers/first_encounter_controller.py
@@ -1,0 +1,44 @@
+import logging
+from typing import Self
+
+from engine.combat.appraisals.basic_attack import BasicAttack
+from engine.combat.controllers.encounter_controller import EncounterController
+from engine.combat.utility.core.action import Action
+from engine.combat.utility.sos_appraisal import SoSTimingType
+from engine.combat.utility.sos_consideration import SoSConsideration
+from memory import (
+    PlayerPartyCharacter,
+    combat_manager_handle,
+)
+
+logger = logging.getLogger(__name__)
+combat_manager = combat_manager_handle()
+
+
+class FirstEncounterController(EncounterController):
+    def generate_action(self: Self) -> bool:
+        if (
+            (self.action is None or self.action.appraisal.complete)
+            and combat_manager.selected_character is not PlayerPartyCharacter.NONE
+            and combat_manager.battle_command_has_focus
+        ):
+            logger.debug("No action exists, executing one one")
+            self.action = self._get_action()
+            return True
+        return False
+
+    def _get_action(self: Self) -> Action:
+        for player in combat_manager.players:
+            if combat_manager.selected_character == player.character:
+                match player.character:
+                    case PlayerPartyCharacter.Valere:
+                        return Action(
+                            SoSConsideration(player),
+                            BasicAttack(timing_type=SoSTimingType.NONE),
+                        )
+                    case PlayerPartyCharacter.Zale:
+                        return Action(
+                            SoSConsideration(player),
+                            BasicAttack(timing_type=SoSTimingType.NONE),
+                        )
+        return None

--- a/engine/combat/controllers/live_mana_tutorial_controller.py
+++ b/engine/combat/controllers/live_mana_tutorial_controller.py
@@ -22,6 +22,8 @@ new_dialog_manager = new_dialog_manager_handle()
 # The classes in encounter controllers are intended to return True if they
 # should short circuit the root combat controller.
 class LiveManaTutorialController(EncounterController):
+    MIN_LIVE_MANA = 5
+
     def generate_action(self: Self) -> bool:
         if (
             (self.action is None or self.action.appraisal.complete)
@@ -36,7 +38,7 @@ class LiveManaTutorialController(EncounterController):
     def _get_action(self: Self) -> Action:
         for player in combat_manager.players:
             if combat_manager.selected_character == player.character:
-                if combat_manager.small_live_mana >= 5:
+                if combat_manager.small_live_mana >= self.MIN_LIVE_MANA:
                     return Action(
                         SoSConsideration(player),
                         BasicAttack(timing_type=SoSTimingType.NONE, boost=1),

--- a/engine/combat/controllers/live_mana_tutorial_controller.py
+++ b/engine/combat/controllers/live_mana_tutorial_controller.py
@@ -7,7 +7,6 @@ from engine.combat.utility.core.action import Action
 from engine.combat.utility.sos_appraisal import SoSTimingType
 from engine.combat.utility.sos_consideration import SoSConsideration
 from memory import (
-    PlayerPartyCharacter,
     combat_manager_handle,
     level_manager_handle,
     new_dialog_manager_handle,
@@ -25,11 +24,7 @@ class LiveManaTutorialController(EncounterController):
     MIN_LIVE_MANA = 5
 
     def generate_action(self: Self) -> bool:
-        if (
-            (self.action is None or self.action.appraisal.complete)
-            and combat_manager.selected_character is not PlayerPartyCharacter.NONE
-            and combat_manager.battle_command_has_focus
-        ):
+        if self._should_generate_action():
             logger.debug("No action exists, executing one one")
             self.action = self._get_action()
             return True

--- a/engine/combat/controllers/live_mana_tutorial_controller.py
+++ b/engine/combat/controllers/live_mana_tutorial_controller.py
@@ -1,0 +1,49 @@
+import logging
+from typing import Self
+
+from engine.combat.appraisals.basic_attack import BasicAttack
+from engine.combat.controllers.encounter_controller import EncounterController
+from engine.combat.utility.core.action import Action
+from engine.combat.utility.sos_appraisal import SoSTimingType
+from engine.combat.utility.sos_consideration import SoSConsideration
+from memory import (
+    PlayerPartyCharacter,
+    combat_manager_handle,
+    level_manager_handle,
+    new_dialog_manager_handle,
+)
+
+logger = logging.getLogger(__name__)
+level_manager = level_manager_handle()
+combat_manager = combat_manager_handle()
+new_dialog_manager = new_dialog_manager_handle()
+
+
+# The classes in encounter controllers are intended to return True if they
+# should short circuit the root combat controller.
+class LiveManaTutorialController(EncounterController):
+    def generate_action(self: Self) -> bool:
+        if (
+            (self.action is None or self.action.appraisal.complete)
+            and combat_manager.selected_character is not PlayerPartyCharacter.NONE
+            and combat_manager.battle_command_has_focus
+        ):
+            logger.debug("No action exists, executing one one")
+            self.action = self._get_action()
+            return True
+        return False
+
+    def _get_action(self: Self) -> Action:
+        for player in combat_manager.players:
+            if combat_manager.selected_character == player.character:
+                if combat_manager.small_live_mana >= 5:
+                    return Action(
+                        SoSConsideration(player),
+                        BasicAttack(timing_type=SoSTimingType.NONE, boost=1),
+                    )
+                return Action(
+                    SoSConsideration(player),
+                    BasicAttack(timing_type=SoSTimingType.NONE),
+                )
+
+        return None

--- a/engine/combat/controllers/second_encounter_controller.py
+++ b/engine/combat/controllers/second_encounter_controller.py
@@ -36,11 +36,7 @@ class SecondEncounterController(EncounterController):
         return False
 
     def generate_action(self: Self) -> bool:
-        if (
-            (self.action is None or self.action.appraisal.complete)
-            and combat_manager.selected_character is not PlayerPartyCharacter.NONE
-            and combat_manager.battle_command_has_focus
-        ):
+        if self._should_generate_action():
             logger.debug("No action exists, executing one one")
             self.action = self._get_action()
             return True

--- a/engine/combat/controllers/second_encounter_controller.py
+++ b/engine/combat/controllers/second_encounter_controller.py
@@ -1,0 +1,74 @@
+import logging
+from typing import Self
+
+from control import sos_ctrl
+from engine.combat.appraisals.basic_attack import BasicAttack
+from engine.combat.appraisals.valere import CrescentArc
+from engine.combat.appraisals.zale import Sunball
+from engine.combat.controllers.encounter_controller import EncounterController
+from engine.combat.utility.core.action import Action
+from engine.combat.utility.sos_appraisal import SoSTimingType
+from engine.combat.utility.sos_consideration import SoSConsideration
+from memory import (
+    PlayerPartyCharacter,
+    combat_manager_handle,
+    new_dialog_manager_handle,
+)
+
+logger = logging.getLogger(__name__)
+combat_manager = combat_manager_handle()
+new_dialog_manager = new_dialog_manager_handle()
+
+
+class SecondEncounterController(EncounterController):
+    def __init__(self: Self) -> None:
+        super().__init__()
+        self.second_attack = False
+
+    def execute_dialog(self: Self) -> bool:
+        if new_dialog_manager.dialog_open:
+            sos_ctrl().toggle_turbo(True)
+            sos_ctrl().confirm()
+            sos_ctrl().toggle_turbo(False)
+            self.action = None
+            self.second_attack = True
+            return True
+        return False
+
+    def generate_action(self: Self) -> bool:
+        if (
+            (self.action is None or self.action.appraisal.complete)
+            and combat_manager.selected_character is not PlayerPartyCharacter.NONE
+            and combat_manager.battle_command_has_focus
+        ):
+            logger.debug("No action exists, executing one one")
+            self.action = self._get_action()
+            return True
+        return False
+
+    def _get_action(self: Self) -> Action:
+        for player in combat_manager.players:
+            if combat_manager.selected_character == player.character:
+                match player.character:
+                    case PlayerPartyCharacter.Valere:
+                        if self.second_attack is True:
+                            return Action(
+                                SoSConsideration(player),
+                                CrescentArc(timing_type=SoSTimingType.NONE),
+                            )
+                        return Action(
+                            SoSConsideration(player),
+                            BasicAttack(timing_type=SoSTimingType.NONE),
+                        )
+                    case PlayerPartyCharacter.Zale:
+                        if self.second_attack is True:
+                            return Action(
+                                SoSConsideration(player),
+                                Sunball(value=1000, hold_time=2.0),
+                            )
+                        return Action(
+                            SoSConsideration(player),
+                            BasicAttack(timing_type=SoSTimingType.NONE),
+                        )
+
+        return None

--- a/engine/combat/utility/sos_appraisal.py
+++ b/engine/combat/utility/sos_appraisal.py
@@ -60,8 +60,6 @@ class SoSAppraisal(Appraisal):
         super().__init__()
 
         self.combat_manager = combat_manager_handle()
-        self.ctrl = sos_ctrl()
-        self.ctrl.delay = 0.1
         self.complete = False
         self.battle_command = SoSBattleCommand.Attack
         self.skill_command_index = 0
@@ -123,8 +121,7 @@ class SoSAppraisal(Appraisal):
 
             for boost in range(self.boost):
                 logger.debug(f"Triggering Boost: {boost + 1}")
-                sos_ctrl().confirm()
-                time.sleep(0.2)
+                sos_ctrl().confirm(tapping=True)
 
             sos_ctrl().toggle_boost(False)
         self.step = SoSAppraisalStep.ConfirmCommand
@@ -134,7 +131,7 @@ class SoSAppraisal(Appraisal):
             self.combat_manager.battle_command_has_focus
             and self.combat_manager.battle_command_index == self.battle_command.value
         ):
-            self.ctrl.confirm()
+            sos_ctrl().confirm()
             # Attack skips to selecting enemy sequence
             match self.battle_command:
                 case SoSBattleCommand.Attack:
@@ -171,7 +168,7 @@ class SoSAppraisal(Appraisal):
             and self.combat_manager.skill_command_has_focus
             and self.combat_manager.skill_command_index == self.skill_command_index
         ):
-            self.ctrl.confirm()
+            sos_ctrl().confirm()
             # Attack skips to selecting enemy sequence
             match self.battle_command:
                 case SoSBattleCommand.Skill | SoSBattleCommand.Combo:
@@ -218,7 +215,7 @@ class SoSAppraisal(Appraisal):
     def execute_confirm_enemy_sequence(self: Self) -> None:
         if self.combat_manager.selected_character != PlayerPartyCharacter.NONE:
             logger.debug("Confirming Enemy")
-            self.ctrl.confirm()
+            sos_ctrl().confirm()
         else:
             self.step = SoSAppraisalStep.TimingSequence
             logger.debug("Confirmed Target")
@@ -230,7 +227,7 @@ class SoSAppraisal(Appraisal):
                 # need a way to bail out if missed timing
                 if self.is_player_timed_attack_ready():
                     logger.debug("Executing Timing Attack")
-                    self.ctrl.confirm()
+                    sos_ctrl().confirm()
                     self.step = SoSAppraisalStep.ActionComplete
             case SoSTimingType.Charge:
                 # Hold Button until timing ready

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -4,6 +4,7 @@ from memory.combat_manager import (
     CombatManager,
     CombatPlayer,
     NextCombatAction,
+    NextCombatEnemy,
     combat_manager_handle,
 )
 from memory.core import SoSMemory, mem_handle
@@ -37,5 +38,6 @@ __all__ = [
     "CombatManager",
     "CombatPlayer",
     "NextCombatAction",
+    "NextCombatEnemy",
     "CombatEncounter",
 ]

--- a/memory/new_dialog_manager.py
+++ b/memory/new_dialog_manager.py
@@ -19,7 +19,9 @@ class NewDialogManager:
         if self.memory.ready_for_updates:
             try:
                 if self.base is None or self.fields_base is None:
-                    singleton_ptr = self.memory.get_singleton_by_class_name("NewDialogManager")
+                    singleton_ptr = self.memory.get_singleton_by_class_name(
+                        "NewDialogManager"
+                    )
                     if singleton_ptr is None:
                         return
                     self.base = self.memory.get_class_base(singleton_ptr)
@@ -27,7 +29,7 @@ class NewDialogManager:
                         return
                     self.fields_base = self.memory.get_class_fields_base(singleton_ptr)
                     self.opened_dialog_boxes_base = self.memory.get_field(
-                        self.fields_base, "openedDialogBoxes"
+                        self.fields_base, "onDialogCompleted"
                     )
 
                 else:
@@ -40,12 +42,9 @@ class NewDialogManager:
         # NewDialogManager -> openedDialogBoxes -> 0x18 -> 0x30 (NewDialogBox)
         try:
             dialog_box_pointer = self.memory.follow_pointer(
-                self.base, [self.opened_dialog_boxes_base, 0x18, 0x30, 0x0]
+                self.base, [self.opened_dialog_boxes_base, 0x0]
             )
-            dialog_box_pointer_2 = self.memory.follow_pointer(
-                self.base, [self.opened_dialog_boxes_base, 0x18, 0x48, 0x0]
-            )
-            if dialog_box_pointer != 0x0 or dialog_box_pointer_2 != 0x0:
+            if dialog_box_pointer != 0x0:
                 self.dialog_open = True
             else:
                 self.dialog_open = False


### PR DESCRIPTION
- Refactors combat controller to be more modularized
- Extracts First/Second controllers
- Implements LiveManaTutorialController
- Implements boost stage + controls
- Moves to Mash Block for all abilities

This implements boosting in a simple way - if there's a preferred way feel free to comment.

This should also allow the TAS to pass the first Live Mana Tutorial. 

We need to make a decision on if we want to fully boost every attack or wait until we implement real appraisals, as this doesn't handle the rest of the fights in elder mist. 

For handling those fights, we can likely use the same controller, but check zone or enemy in https://github.com/shenef/SoS-TAS/pull/146/files#diff-60d3703296529a511733b938fe14ab7d7c8370c5076b2ee3c9efed9683a7d591R69-R78