### PR TITLE
Level up

### DIFF
--- a/GUI/battle_menu.py
+++ b/GUI/battle_menu.py
@@ -5,20 +5,117 @@ from imgui_bundle import imgui
 
 from GUI.GUI import LayoutHelper, Window
 from GUI.menu import Menu
-from memory import combat_manager_handle
+from memory import combat_manager_handle, level_up_manager_handle
 
 logger = logging.getLogger(__name__)
 
 combat_manager = combat_manager_handle()
+level_up_manager = level_up_manager_handle()
 
 
 class BattleMenu(Menu):
+    """GUI window for displaying combat-related information."""
+
     # Determines the amount of columns, 4 is enough for most scenarios.
     # If there are more than 4 enemies, it'll just flow over into the player columns.
     COLUMN_MAX = 3
 
     def __init__(self: Self, window: Window) -> None:
         super().__init__(window, title="Battle menu")
+
+    def render_combat_gui(self: Self) -> None:
+        """Combat GUI."""
+        imgui.text_wrapped(f"Battle Command has focus: {combat_manager.battle_command_has_focus} |")
+        imgui.same_line()
+        imgui.text_wrapped(f"Index: {combat_manager.battle_command_index}")
+        imgui.text_wrapped(f"Skill Command has focus: {combat_manager.skill_command_has_focus} |")
+        imgui.same_line()
+        imgui.text_wrapped(f"Index: {combat_manager.skill_command_index}")
+        imgui.text_wrapped(f"Live Mana Small: {combat_manager.small_live_mana} |")
+        imgui.same_line()
+        imgui.text_wrapped(f"Big: {combat_manager.big_live_mana}")
+        imgui.text_wrapped(f"Selected Character: {combat_manager.selected_character.value}")
+        att_target = (
+            combat_manager.selected_attack_target_guid.replace("\x00", "")
+            if combat_manager.selected_attack_target_guid
+            else "None"
+        )
+        imgui.text_wrapped(f"Attack target: {att_target}")
+        skill_target = (
+            combat_manager.selected_skill_target_guid.replace("\x00", "")
+            if combat_manager.selected_skill_target_guid
+            else "None"
+        )
+        imgui.text_wrapped(f"Skill target: {skill_target}")
+        imgui.separator()
+        imgui.text_wrapped(f"Moonerang Bounces: {combat_manager.projectile_hit_count} |")
+        imgui.same_line()
+        imgui.text_wrapped(f"Moonerang Travel Speed: {combat_manager.projectile_speed:.0f}/75")
+        imgui.separator()
+        imgui.columns(self.COLUMN_MAX)
+
+        if combat_manager.enemies is not []:
+            for idx, enemy in enumerate(combat_manager.enemies):
+                if not enemy.name:
+                    imgui.text(f"({idx}) guid")
+                    imgui.same_line()
+                    imgui.input_text(f"##{idx}", enemy.guid)
+                    LayoutHelper.add_tooltip("Enter this data in memory > mappers > enemy_name.py")
+                else:
+                    imgui.text(f"{enemy.name} ({idx}):")
+                imgui.text(f"HP: {enemy.current_hp}/{enemy.max_hp}")
+                attack_targeted = enemy.unique_id == combat_manager.selected_attack_target_guid
+                skill_targeted = enemy.unique_id == combat_manager.selected_skill_target_guid
+
+                imgui.text_wrapped(f"pATK: {enemy.physical_attack} |")
+                imgui.same_line()
+                imgui.text_wrapped(f"mATK: {enemy.magic_attack}")
+                imgui.text_wrapped(f"pDEF: {enemy.physical_defense} |")
+                imgui.same_line()
+                imgui.text_wrapped(f"mDEF: {enemy.magic_defense}")
+                imgui.text_wrapped(f"Speed: {enemy.speed}")
+                imgui.text_wrapped(f"Attack Targeted: {attack_targeted}")
+                imgui.text_wrapped(f"Skill Targeted: {skill_targeted}")
+                imgui.text_wrapped(f"Next action: {enemy.turns_to_action}")
+                imgui.text_wrapped(f"Locks: {enemy.total_spell_locks}")
+
+                for lock in enemy.spell_locks:
+                    imgui.bullet_text(f"{lock.damage_type.name}")
+                imgui.next_column()
+
+            columns_remaining = self.COLUMN_MAX - len(combat_manager.enemies)
+            for _column in range(columns_remaining):
+                imgui.next_column()
+            imgui.separator()
+
+        if combat_manager.players is not []:
+            for player in combat_manager.players:
+                imgui.text_wrapped(f"{player.character.value}:")
+                imgui.text_wrapped(f"HP: {player.current_hp} |")
+                imgui.same_line()
+                imgui.text_wrapped(f"MP: {player.current_mp}")
+                imgui.text_wrapped(f"Dead: {player.dead}")
+                imgui.text_wrapped(f"Selected: {player.selected}")
+                imgui.text_wrapped(f"Enabled: {player.enabled}")
+                imgui.text_wrapped(f"Mana Charge: {player.mana_charge_count}")
+
+                imgui.next_column()
+
+            columns_remaining = self.COLUMN_MAX - len(combat_manager.players)
+            for _column in range(columns_remaining):
+                imgui.next_column()
+
+    def render_level_up_gui(self: Self) -> None:
+        """Level-up GUI."""
+        imgui.text_wrapped("Level-up screen:")
+        imgui.text_wrapped(f"Current active character: {level_up_manager.current_character}")
+        imgui.text_wrapped(f"Active index: {level_up_manager.active_index}")
+        LayoutHelper.add_spacer()
+        for idx, upgrade in enumerate(level_up_manager.current_upgrades):
+            imgui.text_wrapped(f"Upgrade[{idx}]: {upgrade.upgrade_type.name}")
+            if upgrade.active:
+                imgui.same_line()
+                imgui.text_wrapped(" (Active)")
 
     def execute(self: Self, top_level: bool) -> bool:
         self.window.start_window(self.title)
@@ -30,92 +127,14 @@ class BattleMenu(Menu):
         imgui.text_wrapped(f"Encounter done: {combat_manager.encounter_done} |")
         imgui.same_line()
         imgui.text_wrapped(f"Combat Controller: {combat_manager.combat_controller.name}")
-        if not combat_manager.encounter_done:
-            imgui.text_wrapped(
-                f"Battle Command has focus: {combat_manager.battle_command_has_focus} |"
-            )
-            imgui.same_line()
-            imgui.text_wrapped(f"Index: {combat_manager.battle_command_index}")
-            imgui.text_wrapped(
-                f"Skill Command has focus: {combat_manager.skill_command_has_focus} |"
-            )
-            imgui.same_line()
-            imgui.text_wrapped(f"Index: {combat_manager.skill_command_index}")
-            imgui.text_wrapped(f"Live Mana Small: {combat_manager.small_live_mana} |")
-            imgui.same_line()
-            imgui.text_wrapped(f"Big: {combat_manager.big_live_mana}")
-            imgui.text_wrapped(f"Selected Character: {combat_manager.selected_character.value}")
-            att_target = (
-                combat_manager.selected_attack_target_guid.replace("\x00", "")
-                if combat_manager.selected_attack_target_guid
-                else "None"
-            )
-            imgui.text_wrapped(f"Attack target: {att_target}")
-            skill_target = (
-                combat_manager.selected_skill_target_guid.replace("\x00", "")
-                if combat_manager.selected_skill_target_guid
-                else "None"
-            )
-            imgui.text_wrapped(f"Skill target: {skill_target}")
-            imgui.separator()
-            imgui.text_wrapped(f"Moonerang Bounces: {combat_manager.projectile_hit_count} |")
-            imgui.same_line()
-            imgui.text_wrapped(f"Moonerang Travel Speed: {combat_manager.projectile_speed:.0f}/75")
-            imgui.separator()
-            imgui.columns(self.COLUMN_MAX)
 
-            if combat_manager.enemies is not []:
-                for idx, enemy in enumerate(combat_manager.enemies):
-                    if not enemy.name:
-                        imgui.text(f"({idx}) guid")
-                        imgui.same_line()
-                        imgui.input_text(f"##{idx}", enemy.guid)
-                        LayoutHelper.add_tooltip(
-                            "Enter this data in memory > mappers > enemy_name.py"
-                        )
-                    else:
-                        imgui.text(f"{enemy.name} ({idx}):")
-                    imgui.text(f"HP: {enemy.current_hp}/{enemy.max_hp}")
-                    attack_targeted = enemy.unique_id == combat_manager.selected_attack_target_guid
-                    skill_targeted = enemy.unique_id == combat_manager.selected_skill_target_guid
+        if combat_manager.encounter_done is False:
+            LayoutHelper.add_spacer()
+            self.render_combat_gui()
+        if level_up_manager.level_up_screen_active:
+            LayoutHelper.add_spacer()
+            self.render_level_up_gui()
 
-                    imgui.text_wrapped(f"pATK: {enemy.physical_attack} |")
-                    imgui.same_line()
-                    imgui.text_wrapped(f"mATK: {enemy.magic_attack}")
-                    imgui.text_wrapped(f"pDEF: {enemy.physical_defense} |")
-                    imgui.same_line()
-                    imgui.text_wrapped(f"mDEF: {enemy.magic_defense}")
-                    imgui.text_wrapped(f"Speed: {enemy.speed}")
-                    imgui.text_wrapped(f"Attack Targeted: {attack_targeted}")
-                    imgui.text_wrapped(f"Skill Targeted: {skill_targeted}")
-                    imgui.text_wrapped(f"Next action: {enemy.turns_to_action}")
-                    imgui.text_wrapped(f"Locks: {enemy.total_spell_locks}")
-
-                    for lock in enemy.spell_locks:
-                        imgui.bullet_text(f"{lock.damage_type.name}")
-                    imgui.next_column()
-
-                columns_remaining = self.COLUMN_MAX - len(combat_manager.enemies)
-                for _column in range(columns_remaining):
-                    imgui.next_column()
-                imgui.separator()
-
-            if combat_manager.players is not []:
-                for player in combat_manager.players:
-                    imgui.text_wrapped(f"{player.character.value}:")
-                    imgui.text_wrapped(f"HP: {player.current_hp} |")
-                    imgui.same_line()
-                    imgui.text_wrapped(f"MP: {player.current_mp}")
-                    imgui.text_wrapped(f"Dead: {player.dead}")
-                    imgui.text_wrapped(f"Selected: {player.selected}")
-                    imgui.text_wrapped(f"Enabled: {player.enabled}")
-                    imgui.text_wrapped(f"Mana Charge: {player.mana_charge_count}")
-
-                    imgui.next_column()
-
-                columns_remaining = self.COLUMN_MAX - len(combat_manager.players)
-                for _column in range(columns_remaining):
-                    imgui.next_column()
         ret = False
         if not top_level and imgui.button("Back"):
             ret = True

--- a/engine/combat/combat_controller.py
+++ b/engine/combat/combat_controller.py
@@ -1,4 +1,5 @@
 import logging
+from enum import Enum, auto
 from typing import Self
 
 from control import sos_ctrl
@@ -12,24 +13,39 @@ from memory import (
     CombatEncounter,
     combat_manager_handle,
     level_manager_handle,
+    level_up_manager_handle,
     new_dialog_manager_handle,
 )
 
 logger = logging.getLogger(__name__)
 level_manager = level_manager_handle()
+level_up_manager = level_up_manager_handle()
 combat_manager = combat_manager_handle()
 new_dialog_manager = new_dialog_manager_handle()
 
 
 class CombatController:
+    LEVEL_UP_TIMEOUT = 10.0
+
+    class FSM(Enum):
+        """FSM States."""
+
+        IDLE = auto()
+        COMBAT = auto()
+        AFTER_COMBAT = auto()
+        LEVEL_UP_SCREEN = auto()
+
     def __init__(self: Self) -> None:
         """Initialize a new CombatController object."""
         self.controller = None
+        self.state = CombatController.FSM.IDLE
+        self.timer = 0
 
-    # returns a bool to feed to the sequencer
-    def execute_combat(self: Self, delta: float) -> bool:
-        sos_ctrl().set_neutral()
+    def is_done(self: Self) -> bool:
+        return self.state in [CombatController.FSM.IDLE, CombatController.FSM.AFTER_COMBAT]
 
+    def update_state(self: Self, delta: float) -> None:
+        """Update the FSM. Should be called before execute_combat."""
         # Assign a controller, or the correct controller if it changes.
         # This is because sometimes when we check, the controller has not been
         # set by the game yet, or potentially a change in controllers during a fight.
@@ -41,6 +57,35 @@ class CombatController:
             logger.debug("Setting New Combat Controller")
             self.controller = self._encounter_controller_factory()
             logger.debug(f"Using: {self.controller.__class__.__name__}")
+
+        if self.controller.encounter_done() is False:
+            self.state = CombatController.FSM.COMBAT
+
+        match self.state:
+            case CombatController.FSM.IDLE:
+                pass
+            case CombatController.FSM.COMBAT:
+                if self.controller.encounter_done():
+                    self.timer = 0
+                    self.state = CombatController.FSM.AFTER_COMBAT
+            case CombatController.FSM.AFTER_COMBAT:
+                self.timer += delta
+                if self.timer >= self.LEVEL_UP_TIMEOUT:
+                    self.state = CombatController.FSM.IDLE
+                if level_up_manager.level_up_screen_active:
+                    self.state = CombatController.FSM.LEVEL_UP_SCREEN
+            case CombatController.FSM.LEVEL_UP_SCREEN:
+                if level_up_manager.level_up_screen_active is False:
+                    self.state = CombatController.FSM.IDLE
+
+    # returns a bool to feed to the sequencer
+    def execute_combat(self: Self, delta: float) -> bool:
+        sos_ctrl().set_neutral()
+
+        if self.state == CombatController.FSM.LEVEL_UP_SCREEN:
+            # TODO(orkaboy): Very temporary code to mash past level up screen
+            sos_ctrl().confirm(tapping=True)
+            return False
 
         if self.controller.encounter_done():
             self.controller = None

--- a/engine/combat/level_up.py
+++ b/engine/combat/level_up.py
@@ -1,0 +1,51 @@
+"""Code that decides the best level up path."""
+
+import logging
+
+from control import sos_ctrl
+from memory import (
+    LevelUpUpgradeType,
+    level_up_manager_handle,
+)
+
+logger = logging.getLogger(__name__)
+
+level_up_manager = level_up_manager_handle()
+
+# Priority of stats (higher up has higher priority)
+STAT_PRIORITY = [
+    LevelUpUpgradeType.SkillPoint,
+    LevelUpUpgradeType.MagicAttack,
+    LevelUpUpgradeType.PhysicalAttack,
+    LevelUpUpgradeType.HitPoint,
+    LevelUpUpgradeType.MagicDefense,
+    LevelUpUpgradeType.PhysicalDefense,
+]
+
+
+def handle_level_up() -> None:
+    """Handle deciding level-ups."""
+    ctrl = sos_ctrl()
+
+    # TODO(orkaboy): Currently uses the same stat priority for all characters
+    active_char = level_up_manager.current_character
+
+    # Decide on best option
+    best_option: LevelUpUpgradeType = LevelUpUpgradeType.NONE
+    best_index = 99  # Not chosen
+    for upgrade in level_up_manager.current_upgrades:
+        considered_index = STAT_PRIORITY.index(upgrade.upgrade_type)
+        if considered_index < best_index:
+            best_index = considered_index
+            best_option = upgrade.upgrade_type
+
+    # Navigate to the correct option
+    # TODO(orkaboy): Change this when active_index works?
+    for upgrade in level_up_manager.current_upgrades:
+        if upgrade.upgrade_type == best_option and upgrade.active:
+            ctrl.confirm(tapping=True)
+            # TODO(orkaboy): Spam?
+            logger.debug(f"Selecting upgrade {upgrade.upgrade_type.name} for {active_char.name}")
+            return
+    # Haven't reached the desired option yet, change to next
+    ctrl.dpad.tap_right()

--- a/engine/combat/manual.py
+++ b/engine/combat/manual.py
@@ -4,9 +4,10 @@ from typing import Self
 from control import sos_ctrl
 from engine.mathlib import Vec3
 from engine.seq.move import CancelMove, HoldDirection, InteractMove, MoveToward, SeqMove
-from memory import combat_manager_handle
+from memory import combat_manager_handle, level_up_manager_handle
 
 combat_manager = combat_manager_handle()
+level_up_manager = level_up_manager_handle()
 
 
 # TODO(orkaboy): Temporary code, moves along path, pausing while combat is active
@@ -38,14 +39,18 @@ class SeqCombatManual(SeqMove):
 
     # Override
     def navigate_to_checkpoint(self: Self, delta: float) -> None:
-        if combat_manager.encounter_done:
+        ctrl = sos_ctrl()
+        encounter_done = (
+            combat_manager.encounter_done and level_up_manager.level_up_screen_active is False
+        )
+        if encounter_done:
             # If there is no active fight, move along the designated path
             super().navigate_to_checkpoint(delta)
         elif self.encounter_done:
-            ctrl = sos_ctrl()
             ctrl.set_neutral()
             ctrl.toggle_confirm(False)
         else:
             # Manual control, do nothing
-            pass
-        self.encounter_done = combat_manager.encounter_done
+            ctrl.set_neutral()
+            ctrl.toggle_confirm(False)
+        self.encounter_done = encounter_done

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -9,7 +9,12 @@ from memory.combat_manager import (
 )
 from memory.core import SoSMemory, mem_handle
 from memory.level_manager import level_manager_handle
-from memory.level_up_manager import level_up_manager_handle
+from memory.level_up_manager import (
+    LevelUpManager,
+    LevelUpUpgrade,
+    LevelUpUpgradeType,
+    level_up_manager_handle,
+)
 from memory.mappers.enemy_name import EnemyName
 from memory.mappers.player_party_character import PlayerPartyCharacter
 from memory.new_dialog_manager import new_dialog_manager_handle
@@ -26,6 +31,9 @@ __all__ = [
     "boat_manager_handle",
     "combat_manager_handle",
     "level_up_manager_handle",
+    "LevelUpManager",
+    "LevelUpUpgrade",
+    "LevelUpUpgradeType",
     "level_manager_handle",
     "new_dialog_manager_handle",
     "player_party_manager_handle",

--- a/memory/level_up_manager.py
+++ b/memory/level_up_manager.py
@@ -92,11 +92,11 @@ class LevelUpManager:
         try:
             items = self.memory.follow_pointer(self.base, [0xB0, 0x10, 0x0])
         except Exception:
-            self.current_level_up_upgrades = []
+            self.current_upgrades = []
             return
 
         if items in {self.NULL_POINTER, self.ZERO_NULL_POINTER}:
-            self.current_level_up_upgrades = []
+            self.current_upgrades = []
             return
         # Item is an array of pointers of size 0x08
         upgrades = []

--- a/memory/level_up_manager.py
+++ b/memory/level_up_manager.py
@@ -32,9 +32,11 @@ class LevelUpManager:
 
     def __init__(self: Self) -> None:
         """Initialize a new LevelUpManager object."""
+        # Memory related information
         self.memory = mem_handle()
         self.base = None
         self.fields_base = None
+        # Data fields
         self.level_up_screen_active: bool = False
         self.current_upgrades: list[LevelUpUpgrade] = []
         self.active_index = None

--- a/route/evermist_island/elder_mist.py
+++ b/route/evermist_island/elder_mist.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Self
 
-from engine.combat import SeqCombat, SeqCombatManual
+from engine.combat import SeqCombat, SeqCombatAndMove, SeqCombatManual
 from engine.mathlib import Vec2, Vec3
 from engine.seq import (
     HoldDirection,
@@ -318,8 +318,7 @@ class ElderMistTrials(SeqList):
         super().__init__(
             name="Elder Mist Trials",
             children=[
-                # TODO(orkaboy): Manual. Fix with correct combat
-                SeqCombatManual(
+                SeqCombatAndMove(
                     name="Live Mana Tutorial",
                     coords=[
                         Vec3(48.570, 1.002, -6.019),

--- a/route/evermist_island/final_trials.py
+++ b/route/evermist_island/final_trials.py
@@ -70,8 +70,8 @@ class IntroFinalTrial(SeqList):
                     name="Move to chest",
                     coords=[
                         Vec3(41.031, -7.998, -338.552),
-                        Vec3(40.723, -7.998, -341.119),
-                        InteractMove(24.618, -7.998, -341.119),
+                        Vec3(40.723, -7.998, -340.119),
+                        InteractMove(24.618, -7.998, -340.119),
                         Vec3(24.618, -7.998, -334.883),
                     ],
                 ),

--- a/route/evermist_island/final_trials.py
+++ b/route/evermist_island/final_trials.py
@@ -97,7 +97,7 @@ class IntroFinalTrial(SeqList):
                 SeqHoldDirectionUntilCombat(
                     name="Attack enemies",
                     joy_dir=Vec2(0, -1),
-                    mash_confirm=True,  # TODO(orkaboy): May not be worth it for the 1 dmg
+                    mash_confirm=True,
                 ),
                 SeqCombatAndMove(
                     name="Fight enemies",
@@ -166,8 +166,7 @@ class IntroFinalTrial(SeqList):
                 SeqInteract("Pillar"),
                 SeqSkipUntilCombat("Wyrd"),
                 SeqCombat("Wyrd"),
-                # TODO(orkaboy): Implement proper level up
-                SeqMashUntilIdle("TEMP: Level up & cutscene"),
+                SeqMashUntilIdle("Wyrd cutscene"),
                 SeqMove(
                     name="Leave dungeon",
                     coords=[

--- a/route/sleeper_island/moorlands.py
+++ b/route/sleeper_island/moorlands.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Self
 
-from engine.combat import SeqCombat, SeqCombatAndMove
+from engine.combat import SeqCombatAndMove
 from engine.mathlib import Vec2, Vec3
 from engine.seq import (
     HoldDirection,
@@ -319,9 +319,8 @@ class Moorlands(SeqList):
                                 joy_dir=Vec2(1, 0),
                                 mash_confirm=True,
                             ),
-                            SeqCombat("Fight puzzle guards"),
-                            SeqMove(
-                                name="Move to puzzle",
+                            SeqCombatAndMove(
+                                name="Fight puzzle guards",
                                 coords=[
                                     Vec3(444.493, 1.002, -9.073),
                                 ],

--- a/route/sleeper_island/stonemasons.py
+++ b/route/sleeper_island/stonemasons.py
@@ -274,9 +274,8 @@ class WindTunnelMinesFirstFloor(SeqList):
                     joy_dir=Vec2(-1, 0.5),
                     mash_confirm=True,
                 ),
-                SeqCombat("Fight Bushtroo"),
-                SeqMove(
-                    name="Move into tunnel mouth",
+                SeqCombatAndMove(
+                    name="Fight Bushtroo and go into tunnel mouth",
                     coords=[
                         Vec3(99.725, 2.002, 28.737),
                         InteractMove(98.564, 3.002, 29.228),
@@ -387,8 +386,7 @@ class WindTunnelMinesLowerFloor(SeqList):
                 SeqHoldDirectionUntilCombat(
                     name="Attack!", joy_dir=Vec2(-1, -1), mash_confirm=True
                 ),
-                SeqCombat("Bats and ant"),
-                SeqMove(
+                SeqCombatAndMove(
                     name="Move to ladder",
                     coords=[
                         Vec3(-85.505, 1.002, 16.540),
@@ -564,9 +562,8 @@ class WindTunnelMinesLowerFloor(SeqList):
                     joy_dir=Vec2(-1, 1),
                     mash_confirm=True,
                 ),
-                SeqCombat("Fight Bushtroo"),
-                SeqMove(
-                    name="Move to tunnel mouth",
+                SeqCombatAndMove(
+                    name="Fight Bushtroo and move to tunnel mouth",
                     coords=[
                         Vec3(93.373, 1.002, -33.274),
                         InteractMove(92.663, 2.002, -32.462),
@@ -638,9 +635,8 @@ class WindTunnelMinesLowerFloor(SeqList):
                     joy_dir=Vec2(1, 0.5),
                     mash_confirm=True,
                 ),
-                SeqCombat("Fight Bushtroo"),
-                SeqMove(
-                    name="Move into tunnel",
+                SeqCombatAndMove(
+                    name="Fight Bushtroo and move into tunnel",
                     coords=[
                         Vec3(-124.578, 1.002, 95.514),
                         InteractMove(-123.700, 2.002, 96.360),

--- a/route/sleeper_island/wizard_lab.py
+++ b/route/sleeper_island/wizard_lab.py
@@ -310,8 +310,7 @@ class WizardLabBlueArea(SeqList):
                     joy_dir=Vec2(1, -1),
                     mash_confirm=True,
                 ),
-                SeqCombat("Fight"),
-                SeqMove(
+                SeqCombatAndMove(
                     name="Move to pressure plate",
                     coords=[
                         Vec3(286.063, 1.252, -42.584),
@@ -419,11 +418,13 @@ class WizardLabTealArea(SeqList):
                 ),
                 SeqInteract("Summon enemies"),
                 SeqHoldDirectionUntilCombat("Fight", joy_dir=Vec2(0, -1), mash_confirm=True),
-                SeqCombat("Fight #1"),
+                SeqCombatAndMove(
+                    name="Fight #1",
+                    coords=Vec3(-98.264, 5.002, 161.106),
+                ),
                 SeqBlockPuzzle(
                     name="Move block",
                     coords=[
-                        Vec3(-98.264, 5.002, 161.106),
                         Vec3(-100.157, 5.002, 161.106),
                         MistralBracelet(joy_dir=Vec2(0, 1)),
                         Vec3(-101.644, 5.002, 164.377),
@@ -440,8 +441,7 @@ class WizardLabTealArea(SeqList):
                 ),
                 SeqInteract("Summon enemies"),
                 SeqHoldDirectionUntilCombat("Fight", joy_dir=Vec2(0, -1), mash_confirm=True),
-                SeqCombat("Fight #2"),
-                SeqMove(
+                SeqCombatAndMove(
                     name="Move to pillar",
                     coords=[
                         Vec3(-96.902, 5.002, 153.009),
@@ -456,8 +456,7 @@ class WizardLabTealArea(SeqList):
                     ],
                 ),
                 SeqHoldDirectionUntilCombat("Fight", joy_dir=Vec2(1, 1), mash_confirm=True),
-                SeqCombat("Fight #3"),
-                SeqMove(
+                SeqCombatAndMove(
                     name="Move to chest",
                     coords=[
                         Vec3(-86.159, 5.002, 156.983),

--- a/route/sleeper_island/wizard_lab.py
+++ b/route/sleeper_island/wizard_lab.py
@@ -420,7 +420,9 @@ class WizardLabTealArea(SeqList):
                 SeqHoldDirectionUntilCombat("Fight", joy_dir=Vec2(0, -1), mash_confirm=True),
                 SeqCombatAndMove(
                     name="Fight #1",
-                    coords=Vec3(-98.264, 5.002, 161.106),
+                    coords=[
+                        Vec3(-98.264, 5.002, 161.106),
+                    ],
                 ),
                 SeqBlockPuzzle(
                     name="Move block",


### PR DESCRIPTION
Implements detection of level-up state after combat. A small FSM with a timer ensures that the state change is detected. New code handles the navigation of the level up menu.

Decides on the "best" stat to pick on level up. Currently doesn't make different stat decisions for different characters.

Fixes #144 and #145 (might need to tweak the order of best stats)

Verified with a full run. The TAS was consistently able to select the "correct" stats on level up, and didn't desynch.