### PR TITLE
adds zone based encounter controllers and stub enemy controllers

### DIFF
--- a/engine/combat/combat_controller.py
+++ b/engine/combat/combat_controller.py
@@ -76,10 +76,13 @@ class CombatController:
                 return LiveManaTutorialController()
             case _:
                 match map(lambda x: x.guid, combat_manager.enemies):
+                    # Handle Enemy Specific Controllers
                     # Elder Mist Fight
                     case _ as enemies if "962aa552d33fc124782b230fce9185ce" in enemies:
                         return EncounterController()
-                    case _to_zones:
+                    # Handle level specific controllers or fall back to
+                    # standard encounter controller
+                    case _:
                         match level_manager.current_level:
                             # Elder Mist Zone
                             case "11810c4630980eb43abf7fecebfd5a6b":

--- a/engine/combat/combat_controller.py
+++ b/engine/combat/combat_controller.py
@@ -75,4 +75,14 @@ class CombatController:
             case CombatEncounter.LiveManaTutorial:
                 return LiveManaTutorialController()
             case _:
-                return EncounterController()
+                match map(lambda x: x.guid, combat_manager.enemies):
+                    # Elder Mist Fight
+                    case _ as enemies if "962aa552d33fc124782b230fce9185ce" in enemies:
+                        return EncounterController()
+                    case _to_zones:
+                        match level_manager.current_level:
+                            # Elder Mist Zone
+                            case "11810c4630980eb43abf7fecebfd5a6b":
+                                return LiveManaTutorialController()
+                            case _:
+                                return EncounterController()


### PR DESCRIPTION
Adds a section to combat controller that handles enemy specific encounters (using the main enemy - elder mist)
Adds level specific combat controllers for elder mist isle; this should not be used much, but will work for the live mana encounters.

This list orders by most specific to least specific.