### PR TITLE
Player character list

### DIFF
--- a/memory/mappers/player_party_character.py
+++ b/memory/mappers/player_party_character.py
@@ -9,6 +9,7 @@ class PlayerPartyCharacter(Enum):
     Garl = "Garl"
     Serai = "Seraï"
     Reshan = "Resh'an"
+    Bst = "B'st"
 
     def parse_definition_id(definition_id: str) -> Self:
         ascii_data = definition_id.encode("ascii", "ignore")
@@ -23,4 +24,6 @@ class PlayerPartyCharacter(Enum):
             return PlayerPartyCharacter.Serai
         if ascii_data == b"R\x00E\x00S\x00H\x00":
             return PlayerPartyCharacter.Reshan
+        if ascii_data == b"B\x00S\x00T\x00\x00":
+            return PlayerPartyCharacter.Bst
         return PlayerPartyCharacter.NONE

--- a/memory/mappers/player_party_character.py
+++ b/memory/mappers/player_party_character.py
@@ -13,7 +13,6 @@ class PlayerPartyCharacter(Enum):
 
     def parse_definition_id(definition_id: str) -> Self:
         ascii_data = definition_id.encode("ascii", "ignore")
-
         if ascii_data == b"Z\x00A\x00L\x00E\x00":
             return PlayerPartyCharacter.Zale
         if ascii_data == b"V\x00A\x00L\x00E\x00":
@@ -24,6 +23,6 @@ class PlayerPartyCharacter(Enum):
             return PlayerPartyCharacter.Serai
         if ascii_data == b"R\x00E\x00S\x00H\x00":
             return PlayerPartyCharacter.Reshan
-        if ascii_data == b"B\x00S\x00T\x00\x00":
+        if ascii_data == b"B\x00S\x00T\x00\x00\x00":
             return PlayerPartyCharacter.Bst
         return PlayerPartyCharacter.NONE

--- a/memory/player_party_manager.py
+++ b/memory/player_party_manager.py
@@ -62,6 +62,12 @@ class PlayerPartyManager:
     def _read_current_party(self: Self) -> None:
         try:
             current_party_ptr = self.memory.follow_pointer(self.base, [0x98, 0x0])
+            # Item is an array of pointers of size 0x08
+            # this follows playerPartyManager -> 0x98 (currentParty)
+            combat_players = self.memory.follow_pointer(
+                current_party_ptr,
+                [0x10, 0x0],
+            )
         except Exception:
             self.current_party = []
             return
@@ -69,12 +75,7 @@ class PlayerPartyManager:
         if current_party_ptr == self.NULL_POINTER:
             self.current_party = []
             return
-        # Item is an array of pointers of size 0x08
-        # this follows playerPartyManager -> 0x98 (currentParty)
-        combat_players = self.memory.follow_pointer(
-            current_party_ptr,
-            [0x10, 0x0],
-        )
+        
         players = []
 
         if combat_players:


### PR DESCRIPTION
Adds an ordered player character list to player party manager

closes #149

based on a menu with the following:
```
______________________
|  char 0  |  char 3 |
|  char 1  |  char 4 |
|  char 2  |         |
```

the following:

![image](https://github.com/shenef/SoS-TAS/assets/5025835/3119d67c-14e1-4d26-98fe-dd4a67c56039)

will provide:

[<PlayerPartyCharacter.Valere: 'Valere'>, <PlayerPartyCharacter.Reshan: "Resh'an">, <PlayerPartyCharacter.Serai: 'Seraï'>, <PlayerPartyCharacter.Zale: 'Zale'>, <PlayerPartyCharacter.Bst: "B'st">]