### PR TITLE
Priority targets

### DIFF
--- a/GUI/battle_menu.py
+++ b/GUI/battle_menu.py
@@ -51,6 +51,8 @@ class BattleMenu(Menu):
         imgui.text_wrapped(f"Moonerang Bounces: {combat_manager.projectile_hit_count} |")
         imgui.same_line()
         imgui.text_wrapped(f"Moonerang Travel Speed: {combat_manager.projectile_speed:.0f}/75")
+        imgui.same_line()
+        imgui.text_wrapped(f"Ended: {combat_manager.read_back_to_slot()}")
         imgui.separator()
         imgui.columns(self.COLUMN_MAX)
 

--- a/engine/combat/appraisals/basic_attack.py
+++ b/engine/combat/appraisals/basic_attack.py
@@ -15,5 +15,7 @@ class BasicAttack(SoSAppraisal):
     def __init__(
         self: Self, timing_type: SoSTimingType = SoSTimingType.OneHit, boost: int = 0
     ) -> None:
-        super().__init__(boost=boost, timing_type=timing_type, battle_command=SoSBattleCommand.Attack)
+        super().__init__(
+            boost=boost, timing_type=timing_type, battle_command=SoSBattleCommand.Attack
+        )
         self.target_type = SoSTargetType.Enemy

--- a/engine/combat/appraisals/basic_attack.py
+++ b/engine/combat/appraisals/basic_attack.py
@@ -15,6 +15,5 @@ class BasicAttack(SoSAppraisal):
     def __init__(
         self: Self, timing_type: SoSTimingType = SoSTimingType.OneHit, boost: int = 0
     ) -> None:
-        super().__init__(boost=boost, timing_type=timing_type)
-        self.battle_command = SoSBattleCommand.Attack
+        super().__init__(boost=boost, timing_type=timing_type, battle_command=SoSBattleCommand.Attack)
         self.target_type = SoSTargetType.Enemy

--- a/engine/combat/appraisals/valere/crescent_arc.py
+++ b/engine/combat/appraisals/valere/crescent_arc.py
@@ -19,9 +19,8 @@ class CrescentArc(SoSAppraisal):
         timing_type: SoSTimingType = SoSTimingType.OneHit,
         boost: int = 0,
     ) -> None:
-        super().__init__(boost=boost, timing_type=timing_type)
+        super().__init__(boost=boost, timing_type=timing_type, battle_command=SoSBattleCommand.Skill)
         self.value = value
-        self.battle_command = SoSBattleCommand.Skill
         self.target_type = SoSTargetType.Enemy
         # this needs to move to a system that tracks available abilities.
         # May take significant work to determine this unless we do it manually.

--- a/engine/combat/appraisals/valere/crescent_arc.py
+++ b/engine/combat/appraisals/valere/crescent_arc.py
@@ -19,7 +19,9 @@ class CrescentArc(SoSAppraisal):
         timing_type: SoSTimingType = SoSTimingType.OneHit,
         boost: int = 0,
     ) -> None:
-        super().__init__(boost=boost, timing_type=timing_type, battle_command=SoSBattleCommand.Skill)
+        super().__init__(
+            boost=boost, timing_type=timing_type, battle_command=SoSBattleCommand.Skill
+        )
         self.value = value
         self.target_type = SoSTargetType.Enemy
         # this needs to move to a system that tracks available abilities.

--- a/engine/combat/appraisals/valere/moonerang.py
+++ b/engine/combat/appraisals/valere/moonerang.py
@@ -25,9 +25,9 @@ class Moonerang(SoSAppraisal):
         timing_type: SoSTimingType = SoSTimingType.MultiHit,
         boost: int = 0,
     ) -> None:
-        super().__init__(boost=boost, timing_type=timing_type)
+        super().__init__(boost=boost, timing_type=timing_type, battle_command=SoSBattleCommand.Skill)
         self.value = value
-        self.battle_command = SoSBattleCommand.Skill
+        self.battle_command_targeting_type = SoSBattleCommand.Attack
         self.target_type = SoSTargetType.Enemy
         # this needs to move to a system that tracks available abilities.
         # May take significant work to determine this unless we do it manually.

--- a/engine/combat/appraisals/valere/moonerang.py
+++ b/engine/combat/appraisals/valere/moonerang.py
@@ -17,7 +17,7 @@ combat_manager = combat_manager_handle()
 
 
 class Moonerang(SoSAppraisal):
-    HIT_AT_POSITION_VALUE = 0.55
+    HIT_AT_POSITION_VALUE = 0.82
 
     def __init__(
         self: Self,
@@ -25,7 +25,9 @@ class Moonerang(SoSAppraisal):
         timing_type: SoSTimingType = SoSTimingType.MultiHit,
         boost: int = 0,
     ) -> None:
-        super().__init__(boost=boost, timing_type=timing_type, battle_command=SoSBattleCommand.Skill)
+        super().__init__(
+            boost=boost, timing_type=timing_type, battle_command=SoSBattleCommand.Skill
+        )
         self.value = value
         self.battle_command_targeting_type = SoSBattleCommand.Attack
         self.target_type = SoSTargetType.Enemy

--- a/engine/combat/appraisals/zale/sunball.py
+++ b/engine/combat/appraisals/zale/sunball.py
@@ -23,9 +23,8 @@ class Sunball(SoSAppraisal):
         timing_type: SoSTimingType = SoSTimingType.Charge,
         boost: int = 0,
     ) -> None:
-        super().__init__(boost=boost, timing_type=timing_type)
+        super().__init__(boost=boost, timing_type=timing_type, battle_command=SoSBattleCommand.Skill)
         self.value = value
-        self.battle_command = SoSBattleCommand.Skill
         self.target_type = SoSTargetType.Enemy
         # this needs to move to a system that tracks available abilities.
         # May take significant work to determine this unless we do it manually.

--- a/engine/combat/appraisals/zale/sunball.py
+++ b/engine/combat/appraisals/zale/sunball.py
@@ -23,7 +23,9 @@ class Sunball(SoSAppraisal):
         timing_type: SoSTimingType = SoSTimingType.Charge,
         boost: int = 0,
     ) -> None:
-        super().__init__(boost=boost, timing_type=timing_type, battle_command=SoSBattleCommand.Skill)
+        super().__init__(
+            boost=boost, timing_type=timing_type, battle_command=SoSBattleCommand.Skill
+        )
         self.value = value
         self.target_type = SoSTargetType.Enemy
         # this needs to move to a system that tracks available abilities.

--- a/engine/combat/combat_controller.py
+++ b/engine/combat/combat_controller.py
@@ -4,6 +4,7 @@ from typing import Self
 
 from control import sos_ctrl
 from engine.combat.controllers import (
+    ElderMistEncounterController,
     EncounterController,
     FirstEncounterController,
     LiveManaTutorialController,
@@ -127,7 +128,7 @@ class CombatController:
                     # Handle Enemy Specific Controllers
                     # Elder Mist Fight
                     case _ as enemies if "962aa552d33fc124782b230fce9185ce" in enemies:
-                        return EncounterController()
+                        return ElderMistEncounterController()
                     # Handle level specific controllers or fall back to
                     # standard encounter controller
                     case _:

--- a/engine/combat/combat_controller.py
+++ b/engine/combat/combat_controller.py
@@ -28,6 +28,9 @@ new_dialog_manager = new_dialog_manager_handle()
 
 class CombatController:
     LEVEL_UP_TIMEOUT = 5.0
+    # TODO(eein): Use objects/mappers for these later on.
+    ELDER_MIST_ENEMY_GUID = "962aa552d33fc124782b230fce9185ce"
+    ELDER_MIST_TRIAL_LEVEL_GUID = "11810c4630980eb43abf7fecebfd5a6b"
 
     class FSM(Enum):
         """FSM States."""
@@ -127,14 +130,14 @@ class CombatController:
                 match map(lambda x: x.guid, combat_manager.enemies):
                     # Handle Enemy Specific Controllers
                     # Elder Mist Fight
-                    case _ as enemies if "962aa552d33fc124782b230fce9185ce" in enemies:
+                    case _ as enemies if self.ELDER_MIST_GUID in enemies:
                         return ElderMistEncounterController()
                     # Handle level specific controllers or fall back to
                     # standard encounter controller
                     case _:
                         match level_manager.current_level:
                             # Elder Mist Zone
-                            case "11810c4630980eb43abf7fecebfd5a6b":
+                            case self.ELDER_MIST_TRIAL_LEVEL_GUID:
                                 return LiveManaTutorialController()
                             case _:
                                 return EncounterController()

--- a/engine/combat/contexts/reasoner_execution_context.py
+++ b/engine/combat/contexts/reasoner_execution_context.py
@@ -1,0 +1,10 @@
+from typing import Self
+
+
+# Handles configurable parameters for the reasoner.
+class ReasonerExecutionContext:
+    def __init__(self: Self, priority_targets: list[str] = None) -> None:
+        """Initialize a new ReasonerExecutionContext object."""
+        if priority_targets is None:
+            priority_targets = []
+        self.priority_targets: list[str] = priority_targets

--- a/engine/combat/controllers/__init__.py
+++ b/engine/combat/controllers/__init__.py
@@ -1,3 +1,6 @@
+from engine.combat.controllers.elder_mist_controller import (
+    ElderMistEncounterController,
+)
 from engine.combat.controllers.encounter_controller import EncounterController
 from engine.combat.controllers.first_encounter_controller import (
     FirstEncounterController,
@@ -14,4 +17,5 @@ __all__ = [
     "FirstEncounterController",
     "SecondEncounterController",
     "LiveManaTutorialController",
+    "ElderMistEncounterController",
 ]

--- a/engine/combat/controllers/elder_mist_controller.py
+++ b/engine/combat/controllers/elder_mist_controller.py
@@ -1,0 +1,23 @@
+import logging
+from typing import Self
+
+from engine.combat.controllers.encounter_controller import (
+    EncounterController,
+    ReasonerExecutionContext,
+)
+from engine.combat.utility.sos_reasoner import SoSReasoner
+from memory import (
+    combat_manager_handle,
+)
+
+logger = logging.getLogger(__name__)
+combat_manager = combat_manager_handle()
+
+
+class ElderMistEncounterController(EncounterController):
+    def __init__(self: Self) -> None:
+        """Initialize a new ElderMistController object."""
+        super().__init__()
+        priority_list = ["ddc4a3bbf0edb9945ba4b06f96f9c20e"] # elder mist sword
+        reasoner_execution_context = ReasonerExecutionContext(priority_list)
+        self.reasoner = SoSReasoner(reasoner_execution_context)

--- a/engine/combat/controllers/elder_mist_controller.py
+++ b/engine/combat/controllers/elder_mist_controller.py
@@ -1,10 +1,8 @@
 import logging
 from typing import Self
 
-from engine.combat.controllers.encounter_controller import (
-    EncounterController,
-    ReasonerExecutionContext,
-)
+from engine.combat.contexts.reasoner_execution_context import ReasonerExecutionContext
+from engine.combat.controllers.encounter_controller import EncounterController
 from engine.combat.utility.sos_reasoner import SoSReasoner
 from memory import (
     combat_manager_handle,
@@ -14,10 +12,15 @@ logger = logging.getLogger(__name__)
 combat_manager = combat_manager_handle()
 
 
+# This handles the elder mist fight.
+# The general basis of the fight is the sword must be prioritized first,
+# then the boss can be attacked.
 class ElderMistEncounterController(EncounterController):
+    ELDER_MIST_SWORD_GUID = "ddc4a3bbf0edb9945ba4b06f96f9c20e"
+
     def __init__(self: Self) -> None:
         """Initialize a new ElderMistController object."""
         super().__init__()
-        priority_list = ["ddc4a3bbf0edb9945ba4b06f96f9c20e"] # elder mist sword
+        priority_list = [self.ELDER_MIST_SWORD_GUID]
         reasoner_execution_context = ReasonerExecutionContext(priority_list)
         self.reasoner = SoSReasoner(reasoner_execution_context)

--- a/engine/combat/controllers/encounter_controller.py
+++ b/engine/combat/controllers/encounter_controller.py
@@ -81,7 +81,7 @@ class EncounterController:
                 logger.debug(f"Spam Block for {next_combat_enemy.move_name} Casting")
                 sos_ctrl().confirm()
 
-                return True
+            return True
         return False
 
     # TODO(eein): This should also take into considerations swapping characters into the game field.

--- a/engine/combat/controllers/encounter_controller.py
+++ b/engine/combat/controllers/encounter_controller.py
@@ -2,6 +2,7 @@ import logging
 from typing import Self
 
 from control import sos_ctrl
+from engine.combat.contexts.reasoner_execution_context import ReasonerExecutionContext
 from engine.combat.utility.core.action import Action
 from engine.combat.utility.sos_reasoner import SoSReasoner
 from memory import (
@@ -24,7 +25,7 @@ new_dialog_manager = new_dialog_manager_handle()
 class EncounterController:
     def __init__(self: Self) -> None:
         """Initialize a new EncounterController object."""
-        self.reasoner = SoSReasoner()
+        self.reasoner = SoSReasoner(ReasonerExecutionContext())
         self.action: Action = None
         self.block_timing = 0.0
 
@@ -58,7 +59,7 @@ class EncounterController:
         so it doesn't start executing before we have control.
         """
         if self._should_generate_action():
-            logger.debug("No action exists, executing one one")
+            logger.debug("No action exists, creating one")
             self.action = self.reasoner.execute()
             return True
         return False

--- a/engine/combat/controllers/first_encounter_controller.py
+++ b/engine/combat/controllers/first_encounter_controller.py
@@ -18,8 +18,9 @@ combat_manager = combat_manager_handle()
 class FirstEncounterController(EncounterController):
     def generate_action(self: Self) -> bool:
         if self._should_generate_action():
-            logger.debug("No action exists, executing one one")
+            logger.debug("No action exists, creating one")
             self.action = self._get_action()
+            print(self.action)
             return True
         return False
 

--- a/engine/combat/controllers/first_encounter_controller.py
+++ b/engine/combat/controllers/first_encounter_controller.py
@@ -20,7 +20,6 @@ class FirstEncounterController(EncounterController):
         if self._should_generate_action():
             logger.debug("No action exists, creating one")
             self.action = self._get_action()
-            print(self.action)
             return True
         return False
 

--- a/engine/combat/controllers/live_mana_tutorial_controller.py
+++ b/engine/combat/controllers/live_mana_tutorial_controller.py
@@ -25,7 +25,7 @@ class LiveManaTutorialController(EncounterController):
 
     def generate_action(self: Self) -> bool:
         if self._should_generate_action():
-            logger.debug("No action exists, executing one one")
+            logger.debug("No action exists, creating one")
             self.action = self._get_action()
             return True
         return False

--- a/engine/combat/controllers/second_encounter_controller.py
+++ b/engine/combat/controllers/second_encounter_controller.py
@@ -38,7 +38,7 @@ class SecondEncounterController(EncounterController):
 
     def generate_action(self: Self) -> bool:
         if self._should_generate_action():
-            logger.debug("No action exists, executing one one")
+            logger.debug("No action exists, creating one")
             self.action = self._get_action()
             return True
         return False

--- a/engine/combat/utility/core/appraisal.py
+++ b/engine/combat/utility/core/appraisal.py
@@ -7,6 +7,7 @@ logger = logging.getLogger(__name__)
 class Appraisal:
     def __init__(self: Self, value: int = 0) -> None:
         self.value = value
+        self.target = None
         self.complete = False
 
     def execute(self: Self) -> None:

--- a/engine/combat/utility/core/appraisal.py
+++ b/engine/combat/utility/core/appraisal.py
@@ -6,9 +6,9 @@ logger = logging.getLogger(__name__)
 
 class Appraisal:
     def __init__(self: Self, value: int = 0) -> None:
-        self.value = value
-        self.target = None
-        self.complete = False
+        self.value: int = value
+        self.target: str = None
+        self.complete: bool = False
 
     def execute(self: Self) -> None:
         logger.debug("No appraiser execution defined.")

--- a/engine/combat/utility/sos_appraisal.py
+++ b/engine/combat/utility/sos_appraisal.py
@@ -55,15 +55,22 @@ class SoSResource(Enum):
 
 class SoSAppraisal(Appraisal):
     def __init__(
-        self: Self, timing_type: SoSTimingType = SoSTimingType.NONE, boost: int = 0
+        self: Self, 
+        timing_type: SoSTimingType = SoSTimingType.NONE, 
+        boost: int = 0, 
+        battle_command: SoSBattleCommand = SoSBattleCommand.Attack
     ) -> None:
         super().__init__()
 
         self.combat_manager = combat_manager_handle()
         self.complete = False
-        self.battle_command = SoSBattleCommand.Attack
+        self.battle_command: SoSBattleCommand = battle_command
         self.skill_command_index = 0
         self.target_type = SoSTargetType.Enemy
+        # the following provides an alternative targeting type for moves that break out of
+        # the normal controller types. Moonerang is an example of this, which acts like a
+        # basic attack when it targets, but is a skill when it is selected
+        self.battle_command_targeting_type: SoSBattleCommand = self.battle_command
         self.timing_type = timing_type
         self.step = SoSAppraisalStep.SelectingCommand
         self.character = PlayerPartyCharacter.NONE
@@ -184,32 +191,16 @@ class SoSAppraisal(Appraisal):
             logger.debug(f"Entering step: {self.step.name}")
 
     def execute_selecting_enemy_sequence(self: Self) -> None:
-        # TODO(eein): this will be similar to consideration that cycles through targets
-        # later until it finds the one where the guid is the same (or the unique id)
-        # we should also ensure the target is selected before initiating the action
-        # This is simply hovering the target and ensures we can move to the next state
-        # Just assume we are targeting something for now
-
-        match self.battle_command:
-            case SoSBattleCommand.Attack:
-                pass
-            case SoSBattleCommand.Skill | SoSBattleCommand.Combo:
-                pass
-            case _:
-                pass
         if (
             self._enemy_targeted()
             and not self.combat_manager.battle_command_has_focus
             and self.combat_manager.battle_command_index is None
-            # TODO(eein): Find better pointer to track selected targets - this one isn't doing
-            # what its supposed to so just check if exists to satisfy the result
-            # This will move to something more specific later
-            # and selected_target
             and self.combat_manager.selected_character != PlayerPartyCharacter.NONE
         ):
             self.step = SoSAppraisalStep.ConfirmEnemySequence
             logger.debug("Selected Target")
             return
+        logger.warn("Enemy Target Not Valid, moving cursor")
         sos_ctrl().dpad.tap_right()
 
     def execute_confirm_enemy_sequence(self: Self) -> None:
@@ -245,26 +236,23 @@ class SoSAppraisal(Appraisal):
         # logger.debug("Action Complete")
 
     def _enemy_targeted(self: Self) -> bool:
-        return True
-        # for enemy in self.combat_manager.enemies:
-        #     match self.battle_command:
-        #         case SoSBattleCommand.Attack:
-        #             return (
-        #                 enemy.unique_id
-        #                 == self.combat_manager.selected_attack_target_guid
-        #             )
-        #         case SoSBattleCommand.Skill | SoSBattleCommand.Combo:
-        #             return (
-        #                 enemy.unique_id
-        #                 == self.combat_manager.selected_skill_target_guid
-        #             )
-        # return False
+        for enemy in self.combat_manager.enemies:
+            if enemy.unique_id == self.target:
+                match self.battle_command_targeting_type:
+                    case SoSBattleCommand.Attack:
+                        if enemy.unique_id == self.combat_manager.selected_attack_target_guid:
+                            return True
+                    
+                    case SoSBattleCommand.Skill | SoSBattleCommand.Combo:
+                        if enemy.unique_id == self.combat_manager.selected_skill_target_guid:
+                            return True
+        return False
 
     def has_resources(self: Self, actor: CombatPlayer) -> bool:
         match self.resource:
             case SoSResource.Mana:
                 return actor.current_mp >= self.cost
-            # Not yet implemented
+            # TODO(eein): Not yet implemented
             # case SoSResource.ComboPoints:
             #     return actor.combo_points >= self.cost
             # case SoSResource.UltimateGauge:

--- a/engine/combat/utility/sos_appraisal.py
+++ b/engine/combat/utility/sos_appraisal.py
@@ -54,6 +54,8 @@ class SoSResource(Enum):
 
 
 class SoSAppraisal(Appraisal):
+    MAX_ENEMY_TARGETING_FAILURES = 6
+
     def __init__(
         self: Self,
         timing_type: SoSTimingType = SoSTimingType.NONE,
@@ -77,6 +79,7 @@ class SoSAppraisal(Appraisal):
         self.resource = SoSResource.NONE
         self.cost = 0
         self.boost = boost
+        self.enemy_targeting_failures = 0
 
     # selects the step to perform based on the current step
     def execute(self: Self) -> None:
@@ -202,6 +205,10 @@ class SoSAppraisal(Appraisal):
             return
         logger.warn("Enemy Target Not Valid, moving cursor")
         sos_ctrl().dpad.tap_right()
+        self.enemy_targeting_failures += 1
+        if self.enemy_targeting_failures >= self.MAX_ENEMY_TARGETING_FAILURES:
+            self.step = SoSAppraisalStep.ConfirmEnemySequence
+            logger.warn("Max Targeting Failures Reached, Confirming Target")
 
     def execute_confirm_enemy_sequence(self: Self) -> None:
         if self.combat_manager.selected_character != PlayerPartyCharacter.NONE:

--- a/engine/combat/utility/sos_appraisal.py
+++ b/engine/combat/utility/sos_appraisal.py
@@ -205,6 +205,9 @@ class SoSAppraisal(Appraisal):
             return
         logger.warn("Enemy Target Not Valid, moving cursor")
         sos_ctrl().dpad.tap_right()
+        # TODO(eein): This will be improved when we have a better way to
+        # detect who we are targeting. For now we just fail after 6 failures
+        # to avoid getting stuck in a loop
         self.enemy_targeting_failures += 1
         if self.enemy_targeting_failures >= self.MAX_ENEMY_TARGETING_FAILURES:
             self.step = SoSAppraisalStep.ConfirmEnemySequence

--- a/engine/combat/utility/sos_appraisal.py
+++ b/engine/combat/utility/sos_appraisal.py
@@ -55,10 +55,10 @@ class SoSResource(Enum):
 
 class SoSAppraisal(Appraisal):
     def __init__(
-        self: Self, 
-        timing_type: SoSTimingType = SoSTimingType.NONE, 
-        boost: int = 0, 
-        battle_command: SoSBattleCommand = SoSBattleCommand.Attack
+        self: Self,
+        timing_type: SoSTimingType = SoSTimingType.NONE,
+        boost: int = 0,
+        battle_command: SoSBattleCommand = SoSBattleCommand.Attack,
     ) -> None:
         super().__init__()
 
@@ -236,13 +236,17 @@ class SoSAppraisal(Appraisal):
         # logger.debug("Action Complete")
 
     def _enemy_targeted(self: Self) -> bool:
+        # If we are doing some custom controller stuff that doesn't need a target, just return True
+        if self.target is None:
+            return True
+
         for enemy in self.combat_manager.enemies:
             if enemy.unique_id == self.target:
                 match self.battle_command_targeting_type:
                     case SoSBattleCommand.Attack:
                         if enemy.unique_id == self.combat_manager.selected_attack_target_guid:
                             return True
-                    
+
                     case SoSBattleCommand.Skill | SoSBattleCommand.Combo:
                         if enemy.unique_id == self.combat_manager.selected_skill_target_guid:
                             return True

--- a/engine/combat/utility/sos_consideration.py
+++ b/engine/combat/utility/sos_consideration.py
@@ -46,7 +46,7 @@ class SoSConsideration(Consideration):
         basic_attack.value = self.actor.physical_attack
 
         return [basic_attack]
-    
+
     # TODO(eein): Calculate appraisals based on skill/combo availability
     def _character_appraisals(self: Self) -> list[Appraisal]:
         match self.actor.character:
@@ -54,7 +54,11 @@ class SoSConsideration(Consideration):
                 return [Sunball(value=100)]
             case PlayerPartyCharacter.Valere:
                 # Currently set up to use moonerang if there is only one enemy
-                if len(combat_manager.enemies) == 1:
+                enemy_count = 0
+                for enemy in combat_manager.enemies:
+                    if enemy.current_hp > 0:
+                        enemy_count += 1
+                if enemy_count == 1:
                     return [Moonerang(value=200)]
                 return [CrescentArc(value=100)]
             case PlayerPartyCharacter.Garl:
@@ -63,10 +67,25 @@ class SoSConsideration(Consideration):
                 return []
 
     def calculate_actions(self: Self) -> list[Action]:
-        # if the actor isn't enabled, return no actions
         actions = []
-
+        # TODO(eein): to give value to boosted appraisals we will just multiply
+        # the value by the boost for now, we can modify this when we work further on
+        # utility.
+        boosted_appraisals = []
         for appraisal in self.appraisals:
+            boosts_available = round(combat_manager.small_live_mana / 5)
+            if boosts_available == 0:
+                boosted_appraisals.append(appraisal)
+                continue
+
+            for boost in range(0, boosts_available + 1):
+                new_appraisal = copy.copy(appraisal)
+                new_appraisal.boost = boost
+                new_appraisal.value = new_appraisal.value * (boost + 1)
+                boosted_appraisals.append(new_appraisal)
+
+        # takes the boosted appraisals, and creates and action for each enemy.
+        for appraisal in boosted_appraisals:
             for enemy in combat_manager.enemies:
                 new_appraisal = copy.copy(appraisal)
                 new_appraisal.target = enemy.unique_id

--- a/engine/combat/utility/sos_consideration.py
+++ b/engine/combat/utility/sos_consideration.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Self
 
 from control import sos_ctrl
@@ -45,7 +46,8 @@ class SoSConsideration(Consideration):
         basic_attack.value = self.actor.physical_attack
 
         return [basic_attack]
-
+    
+    # TODO(eein): Calculate appraisals based on skill/combo availability
     def _character_appraisals(self: Self) -> list[Appraisal]:
         match self.actor.character:
             case PlayerPartyCharacter.Zale:
@@ -63,9 +65,12 @@ class SoSConsideration(Consideration):
     def calculate_actions(self: Self) -> list[Action]:
         # if the actor isn't enabled, return no actions
         actions = []
+
         for appraisal in self.appraisals:
-            # TODO(eein): calculate this for every enemy.
-            actions.append(Action(self, appraisal))
+            for enemy in combat_manager.enemies:
+                new_appraisal = copy.copy(appraisal)
+                new_appraisal.target = enemy.unique_id
+                actions.append(copy.copy(Action(self, new_appraisal)))
         return actions
 
     # execute on selecting the consideration to perform the appraisal

--- a/engine/combat/utility/sos_reasoner.py
+++ b/engine/combat/utility/sos_reasoner.py
@@ -43,14 +43,23 @@ class SoSReasoner(Reasoner):
 
         # sort and return the results by their value in desc order
         actions.sort(key=lambda action: action.appraisal.value, reverse=True)
-
+        for a in actions:
+            print(
+                f"Action: {a.appraisal.value} {a.appraisal.__class__.__name__} {a.appraisal.target}"
+            )
         # filter enemies with no HP (elder mist & botantical horror)
         actions = self._filter_disabled_enemies(actions)
-
+        for a in actions:
+            print(
+                f"Action: {a.appraisal.value} {a.appraisal.__class__.__name__} {a.appraisal.target}"
+            )
         # if we have priority targets, then filter out any actions that don't target them
         if self.reasoner_execution_context.priority_targets is not []:
             actions = self._filter_priority_targets(actions)
-
+        for a in actions:
+            print(
+                f"Action: {a.appraisal.value} {a.appraisal.__class__.__name__} {a.appraisal.target}"
+            )
         if len(actions) == 0:
             return None
         return actions[0]

--- a/engine/combat/utility/sos_reasoner.py
+++ b/engine/combat/utility/sos_reasoner.py
@@ -43,23 +43,14 @@ class SoSReasoner(Reasoner):
 
         # sort and return the results by their value in desc order
         actions.sort(key=lambda action: action.appraisal.value, reverse=True)
-        for a in actions:
-            print(
-                f"Action: {a.appraisal.value} {a.appraisal.__class__.__name__} {a.appraisal.target}"
-            )
+
         # filter enemies with no HP (elder mist & botantical horror)
         actions = self._filter_disabled_enemies(actions)
-        for a in actions:
-            print(
-                f"Action: {a.appraisal.value} {a.appraisal.__class__.__name__} {a.appraisal.target}"
-            )
+
         # if we have priority targets, then filter out any actions that don't target them
         if self.reasoner_execution_context.priority_targets is not []:
             actions = self._filter_priority_targets(actions)
-        for a in actions:
-            print(
-                f"Action: {a.appraisal.value} {a.appraisal.__class__.__name__} {a.appraisal.target}"
-            )
+
         if len(actions) == 0:
             return None
         return actions[0]

--- a/engine/combat/utility/sos_reasoner.py
+++ b/engine/combat/utility/sos_reasoner.py
@@ -1,32 +1,39 @@
+import logging
 from typing import Self
 
+from engine.combat.contexts.reasoner_execution_context import ReasonerExecutionContext
 from engine.combat.utility.core.action import Action
 from engine.combat.utility.core.consideration import Consideration
 from engine.combat.utility.core.reasoner import Reasoner
 from engine.combat.utility.sos_consideration import SoSConsideration
-from memory import CombatPlayer, combat_manager_handle
+from memory import CombatEnemyTarget, CombatPlayer, combat_manager_handle
 
+logger = logging.getLogger(__name__)
 combat_manager = combat_manager_handle()
 
 
 class SoSReasoner(Reasoner):
-    def __init__(self: Self) -> None:
+    def __init__(self: Self, reasoner_execution_context: ReasonerExecutionContext) -> None:
         """Initialize a new SoSReasoner object."""
+        self.reasoner_execution_context = reasoner_execution_context
         self.considerations = []
 
     def generate_considerations(self: Self, players: list[CombatPlayer]) -> list[Consideration]:
+        """Generate considerations for all targets."""
         considerations = []
         for player in players:
-            if not player.dead and player.enabled:
+            if self._can_generate_consideration_for_player(player):
                 considerations.append(SoSConsideration(player))
         return considerations
 
+    
     def execute(self: Self) -> Action:
+        """Generate considerations and select an action off the top of the stack."""
         self.considerations = self.generate_considerations(combat_manager.players)
         return self._select_action()
 
     def _select_action(self: Self) -> Action:
-        # go through each consideration and calculate its value
+        """Calculate value for each consideration and return the highest value action."""
         actions = []
         for consideration in self.considerations:
             calculated_actions = consideration.calculate_actions()
@@ -34,7 +41,49 @@ class SoSReasoner(Reasoner):
 
         if actions == []:
             return None
+
+
         # sort and return the results by their value in desc order
         actions.sort(key=lambda action: action.appraisal.value, reverse=True)
 
+        # filter enemies with no HP (elder mist & botantical horror)
+        actions = self._filter_disabled_enemies(actions)
+       
+        # if we have priority targets, then filter out any actions that don't target them
+        if self.reasoner_execution_context.priority_targets is not []:
+            actions = self._filter_priority_targets(actions)
+
+        if len(actions) == 0:
+            return None
         return actions[0]
+    
+    def _can_generate_consideration_for_player(self: Self, player: CombatPlayer) -> bool:
+        """Check if we can generate a consideration for a player."""
+        if player.dead or not player.enabled:
+            return False
+        return True
+    
+    def _filter_priority_targets(self: Self, actions: list[Action]) -> list[Action]:
+        """Filter out actions that don't target priority targets."""
+        for enemy in combat_manager.enemies:
+            if (
+                self._enemy_is_active(enemy) and 
+                enemy.guid in self.reasoner_execution_context.priority_targets
+            ):
+                return list(filter(lambda a: a.appraisal.target == enemy.unique_id, actions))
+        return actions
+    
+    def _filter_disabled_enemies(self: Self, actions: list[Action]) -> list[Action]:
+        """Filter out actions that don't target active targets."""
+        for enemy in combat_manager.enemies:
+            if not self._enemy_is_active(enemy):
+                actions = list(filter(lambda a: a.appraisal.target != enemy.unique_id, actions))
+        return actions
+    
+    def _enemy_is_active(self: Self, enemy: CombatEnemyTarget) -> bool:
+        """Check if an enemy is active."""
+        return enemy.current_hp > 0
+
+
+        
+        

--- a/engine/combat/utility/sos_reasoner.py
+++ b/engine/combat/utility/sos_reasoner.py
@@ -26,7 +26,6 @@ class SoSReasoner(Reasoner):
                 considerations.append(SoSConsideration(player))
         return considerations
 
-    
     def execute(self: Self) -> Action:
         """Generate considerations and select an action off the top of the stack."""
         self.considerations = self.generate_considerations(combat_manager.players)
@@ -42,13 +41,12 @@ class SoSReasoner(Reasoner):
         if actions == []:
             return None
 
-
         # sort and return the results by their value in desc order
         actions.sort(key=lambda action: action.appraisal.value, reverse=True)
 
         # filter enemies with no HP (elder mist & botantical horror)
         actions = self._filter_disabled_enemies(actions)
-       
+
         # if we have priority targets, then filter out any actions that don't target them
         if self.reasoner_execution_context.priority_targets is not []:
             actions = self._filter_priority_targets(actions)
@@ -56,34 +54,30 @@ class SoSReasoner(Reasoner):
         if len(actions) == 0:
             return None
         return actions[0]
-    
+
     def _can_generate_consideration_for_player(self: Self, player: CombatPlayer) -> bool:
         """Check if we can generate a consideration for a player."""
         if player.dead or not player.enabled:
             return False
         return True
-    
+
     def _filter_priority_targets(self: Self, actions: list[Action]) -> list[Action]:
         """Filter out actions that don't target priority targets."""
         for enemy in combat_manager.enemies:
             if (
-                self._enemy_is_active(enemy) and 
-                enemy.guid in self.reasoner_execution_context.priority_targets
+                self._enemy_is_active(enemy)
+                and enemy.guid in self.reasoner_execution_context.priority_targets
             ):
                 return list(filter(lambda a: a.appraisal.target == enemy.unique_id, actions))
         return actions
-    
+
     def _filter_disabled_enemies(self: Self, actions: list[Action]) -> list[Action]:
         """Filter out actions that don't target active targets."""
         for enemy in combat_manager.enemies:
             if not self._enemy_is_active(enemy):
                 actions = list(filter(lambda a: a.appraisal.target != enemy.unique_id, actions))
         return actions
-    
+
     def _enemy_is_active(self: Self, enemy: CombatEnemyTarget) -> bool:
         """Check if an enemy is active."""
         return enemy.current_hp > 0
-
-
-        
-        

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -1,6 +1,7 @@
 from memory.boat_manager import boat_manager_handle
 from memory.combat_manager import (
     CombatEncounter,
+    CombatEnemyTarget,
     CombatManager,
     CombatPlayer,
     NextCombatAction,
@@ -48,4 +49,5 @@ __all__ = [
     "NextCombatAction",
     "NextCombatEnemy",
     "CombatEncounter",
+    "CombatEnemyTarget",
 ]

--- a/memory/combat_manager.py
+++ b/memory/combat_manager.py
@@ -154,7 +154,8 @@ class CombatManager:
                     if singleton_ptr is None:
                         return
                     self.base = self.memory.get_class_base(singleton_ptr)
-                    self.fields_base = self.memory.get_class_fields_base(singleton_ptr)
+                    self.fields_base = self.memory.get_class_fields_base(
+                        singleton_ptr)
                     self.current_encounter_base = self.memory.get_field(
                         self.fields_base, "currentEncounter"
                     )
@@ -228,7 +229,8 @@ class CombatManager:
                     combat_move_ptr, [0x90, 0x18, 0x10, 0x20, 0x18, 0x0]
                 )
                 move_length = self.memory.read_int(move_ptr + 0x10)
-                move_name = self.memory.read_string(move_ptr + 0x14, move_length * 2)
+                move_name = self.memory.read_string(
+                    move_ptr + 0x14, move_length * 2)
 
                 next_enemy = None
                 for enemy in self.enemies:
@@ -242,7 +244,8 @@ class CombatManager:
                     state_type = NextCombatAction.Casting
                 else:
                     state_type = NextCombatAction.Attacking
-                    movement_done = self.memory.read_bool(current_state_ptr + 0x11A)
+                    movement_done = self.memory.read_bool(
+                        current_state_ptr + 0x11A)
                 self.next_combat_enemy = NextCombatEnemy(
                     enemy=next_enemy,
                     state_type=state_type,
@@ -263,20 +266,20 @@ class CombatManager:
 
     def _read_current_target(self: Self) -> None:
         target_unique_id_base = None
-                  
+
         selected_attack_target_guid = ""
         selected_skill_target_guid = ""
         first_player_ptr = self.memory.follow_pointer(
-                self.base,
-                    [
-                        self.current_encounter_base,
-                        0x120,
-                        0x98,
-                        0x40,
-                        0x10,
-                        0x20,
-                        0x0,
-                    ]
+            self.base,
+            [
+                self.current_encounter_base,
+                0x120,
+                0x98,
+                0x40,
+                0x10,
+                0x20,
+                0x0,
+            ]
         )
         with contextlib.suppress(Exception):
             target_unique_id_base = self.memory.follow_pointer(
@@ -296,7 +299,7 @@ class CombatManager:
                     0x18,
                     0x0,
                 ],
-        )
+            )
 
         # This check was added due to the pointer not falling off in time,
         # referencing an enemy that just died
@@ -354,7 +357,8 @@ class CombatManager:
                     [self.current_encounter_base, 0x120, 0x0, 0x78, 0x10, 0x0],
                 )
 
-                controller = self.memory.read_string(combat_controller_ptr + 0x0, 25)
+                controller = self.memory.read_string(
+                    combat_controller_ptr + 0x0, 25)
                 match controller:
                     case s if s.startswith("FirstEncounter"):
                         self.combat_controller = CombatEncounter.FirstEncounter
@@ -439,8 +443,6 @@ class CombatManager:
                 return 0
         return 0
 
-        # how many times the projectile has hit something (usually 1 more than bounce count)
-
     def read_projectile_speed(self: Self) -> int:
         if self._should_update():
             try:
@@ -460,7 +462,8 @@ class CombatManager:
                 back_to_slot_ptr = self.memory.follow_pointer(
                     self.base, [0x168, 0x18, 0x20, 0x0]
                 )
-                back_to_slot = self.memory.read_bool(back_to_slot_ptr + 0x161)
+                # this is now actually finalHitDelayDone instead of moongirlBackToSlot
+                back_to_slot = self.memory.read_bool(back_to_slot_ptr + 0x160)
                 if back_to_slot:
                     return True
 
@@ -472,7 +475,8 @@ class CombatManager:
     def _read_battle_commands(self: Self) -> None:
         if self._should_update():
             battle_command_selector = self.memory.follow_pointer(
-                self.base, [self.current_encounter_base, 0x138, 0x50, 0x68, 0x0]
+                self.base, [self.current_encounter_base,
+                            0x138, 0x50, 0x68, 0x0]
             )
             # Checks if we lost access to the selector pointer for a brief period as the UI changes.
             if battle_command_selector == self.NULL_POINTER:
@@ -485,7 +489,8 @@ class CombatManager:
                     # Checks an address to see if the battle command menu is visible
                     # and read the index for it if it is available, otherwise set it
                     # back to a NoneType for safety
-                    has_focus = self.memory.read_bool(battle_command_selector + 0x3C)
+                    has_focus = self.memory.read_bool(
+                        battle_command_selector + 0x3C)
 
                     self.battle_command_has_focus = has_focus
                     if has_focus:
@@ -509,7 +514,8 @@ class CombatManager:
     def _read_skill_commands(self: Self) -> None:
         if self._should_update():
             skill_command_selector = self.memory.follow_pointer(
-                self.base, [self.current_encounter_base, 0x138, 0x50, 0x78, 0x0]
+                self.base, [self.current_encounter_base,
+                            0x138, 0x50, 0x78, 0x0]
             )
             # Checks if we lost access to the selector pointer for a brief period as the UI changes.
             if skill_command_selector == self.NULL_POINTER:
@@ -525,7 +531,8 @@ class CombatManager:
                     # as it seems to lose its pointer quite often, especially when the
                     # item menu is open
                     # TODO(eein): Does the skill_command_selector apply to the items menu as well?
-                    has_focus = self.memory.read_bool(skill_command_selector + 0x3C)
+                    has_focus = self.memory.read_bool(
+                        skill_command_selector + 0x3C)
                     selected_item_index = self.memory.read_longlong(
                         skill_command_selector + 0x40
                     )
@@ -583,7 +590,8 @@ class CombatManager:
                 self.big_live_mana = 0
                 return
             if small_live_mana and big_live_mana:
-                self.small_live_mana = self.memory.read_int(small_live_mana + 0x18)
+                self.small_live_mana = self.memory.read_int(
+                    small_live_mana + 0x18)
                 self.big_live_mana = self.memory.read_int(big_live_mana + 0x18)
                 return
 
@@ -597,7 +605,8 @@ class CombatManager:
                 )
                 panel_count = self.memory.read_int(panel_count_ptr + 0x5C)
                 player_panels_list = self.memory.follow_pointer(
-                    self.base, [self.current_encounter_base, 0x120, 0x98, 0x40, 0x0]
+                    self.base, [self.current_encounter_base,
+                                0x120, 0x98, 0x40, 0x0]
                 )
             except Exception:
                 self.players = []
@@ -635,14 +644,16 @@ class CombatManager:
 
                     # Check if the character definition id is 0, and return as the
                     # character cannot be queried against
-                    character_definition_id = self.memory.read_longlong(item + 0x70)
+                    character_definition_id = self.memory.read_longlong(
+                        item + 0x70)
 
                     # If the character isn't loaded, ignore.
                     if character_definition_id == 0:
                         address += self.ITEM_OBJECT_OFFSET
                         continue
 
-                    dead_ptr = self.memory.follow_pointer(item, [0x68, 0x38, 0x0])
+                    dead_ptr = self.memory.follow_pointer(
+                        item, [0x68, 0x38, 0x0])
                     dead = self.memory.read_bool(dead_ptr + 0xD0)
 
                     # tracks timed attacks maybe
@@ -657,17 +668,21 @@ class CombatManager:
                     except Exception:
                         timed_attack_value = False
 
-                    definition_id_ptr = self.memory.follow_pointer(item, [0x70, 0x0])
+                    definition_id_ptr = self.memory.follow_pointer(item, [
+                                                                   0x70, 0x0])
                     # 4 Chars * 2 for utf
-                    definition_id = self.memory.read_string(definition_id_ptr + 0x14, 8)
+                    definition_id = self.memory.read_string(
+                        definition_id_ptr + 0x14, 8)
 
                     # Definition IDS are stored as some goofy serialized utf encoded string
                     # We just do our best with the values that are provided to
                     # Determine the character we are looking at
-                    character = PlayerPartyCharacter.parse_definition_id(definition_id)
+                    character = PlayerPartyCharacter.parse_definition_id(
+                        definition_id)
 
                     selected = self.memory.read_bool(item + 0x78)
-                    hp_text_field = self.memory.follow_pointer(item, [0x28, 0x0])
+                    hp_text_field = self.memory.follow_pointer(
+                        item, [0x28, 0x0])
                     current_hp = self.memory.read_int(hp_text_field + 0x58)
 
                     portrait = self.memory.follow_pointer(item, [0x68, 0x0])
@@ -676,17 +691,18 @@ class CombatManager:
                     live_mana_handler = self.memory.follow_pointer(
                         item, [0x68, 0x38, 0x148, 0x0]
                     )
-                    mana_charge_count = self.memory.read_int(live_mana_handler + 0x58)
+                    mana_charge_count = self.memory.read_int(
+                        live_mana_handler + 0x58)
 
                     if selected:
                         selected_character = character
 
                     player = CombatPlayer()
-                    
-                    mp_text_field = self.memory.follow_pointer(item, [0x30, 0x0])
+
+                    mp_text_field = self.memory.follow_pointer(
+                        item, [0x30, 0x0])
 
                     current_mp = self.memory.read_int(mp_text_field + 0x58)
-
 
                     # TODO(eein): hardcode these for now - we need to extract these players into
                     # something more global and only update them as required.
@@ -772,8 +788,10 @@ class CombatManager:
                     magic_defense = self.memory.read_int(enemy_data + 0x34)
                     enemy_guid = self.memory.read_guid(guid + 0x14)
                     enemy_unique_id = self.memory.read_uuid(unique_id + 0x14)
-                    turns_to_action = self.memory.read_short(casting_data + 0x24)
-                    total_spell_locks = self.memory.read_short(casting_data + 0x28)
+                    turns_to_action = self.memory.read_short(
+                        casting_data + 0x24)
+                    total_spell_locks = self.memory.read_short(
+                        casting_data + 0x28)
 
                     spell_locks: list[CombatSpellLock] = []
 
@@ -789,15 +807,18 @@ class CombatManager:
                             #   - 0x20 - Item[0]
                             #   - 0x28 - Item[1]
                             spell_locks_base = self.memory.follow_pointer(
-                                casting_data, [0x18, 0x10, spell_locks_addr, 0x0]
+                                casting_data, [0x18, 0x10,
+                                               spell_locks_addr, 0x0]
                             )
 
                             if spell_locks_base == 0x0:
                                 continue
 
-                            lock = self.memory.read_int(spell_locks_base + 0x40)
+                            lock = self.memory.read_int(
+                                spell_locks_base + 0x40)
                             spell_locks.append(
-                                CombatSpellLock(damage_type=CombatDamageType(lock))
+                                CombatSpellLock(
+                                    damage_type=CombatDamageType(lock))
                             )
 
                             spell_locks_addr += self.ITEM_OBJECT_OFFSET

--- a/memory/combat_manager.py
+++ b/memory/combat_manager.py
@@ -40,9 +40,7 @@ class CombatDamageType(Enum):
 
 
 class CombatSpellLock:
-    def __init__(
-        self: Self, damage_type: CombatDamageType = CombatDamageType.NONE
-    ) -> None:
+    def __init__(self: Self, damage_type: CombatDamageType = CombatDamageType.NONE) -> None:
         self.name_loc_id = None
         self.damage_type = damage_type
 
@@ -147,15 +145,12 @@ class CombatManager:
             if self.memory.ready_for_updates:
                 if self.base is None or self.fields_base is None:
                     self.encounter_done = True
-                    singleton_ptr = self.memory.get_singleton_by_class_name(
-                        "CombatManager"
-                    )
+                    singleton_ptr = self.memory.get_singleton_by_class_name("CombatManager")
 
                     if singleton_ptr is None:
                         return
                     self.base = self.memory.get_class_base(singleton_ptr)
-                    self.fields_base = self.memory.get_class_fields_base(
-                        singleton_ptr)
+                    self.fields_base = self.memory.get_class_fields_base(singleton_ptr)
                     self.current_encounter_base = self.memory.get_field(
                         self.fields_base, "currentEncounter"
                     )
@@ -215,9 +210,7 @@ class CombatManager:
                     self.next_combat_enemy = None
                     return
                 spell_power = self.memory.read_float(combat_move_ptr + 0x30)
-                guid_ptr = self.memory.follow_pointer(
-                    ongoing_move_ptr, [0xF8, 0xF0, 0x18, 0x0]
-                )
+                guid_ptr = self.memory.follow_pointer(ongoing_move_ptr, [0xF8, 0xF0, 0x18, 0x0])
                 guid = self.memory.read_uuid(guid_ptr + 0x14)
 
                 current_state_ptr = self.memory.follow_pointer(
@@ -229,8 +222,7 @@ class CombatManager:
                     combat_move_ptr, [0x90, 0x18, 0x10, 0x20, 0x18, 0x0]
                 )
                 move_length = self.memory.read_int(move_ptr + 0x10)
-                move_name = self.memory.read_string(
-                    move_ptr + 0x14, move_length * 2)
+                move_name = self.memory.read_string(move_ptr + 0x14, move_length * 2)
 
                 next_enemy = None
                 for enemy in self.enemies:
@@ -244,8 +236,7 @@ class CombatManager:
                     state_type = NextCombatAction.Casting
                 else:
                     state_type = NextCombatAction.Attacking
-                    movement_done = self.memory.read_bool(
-                        current_state_ptr + 0x11A)
+                    movement_done = self.memory.read_bool(current_state_ptr + 0x11A)
                 self.next_combat_enemy = NextCombatEnemy(
                     enemy=next_enemy,
                     state_type=state_type,
@@ -279,7 +270,7 @@ class CombatManager:
                 0x10,
                 0x20,
                 0x0,
-            ]
+            ],
         )
         with contextlib.suppress(Exception):
             target_unique_id_base = self.memory.follow_pointer(
@@ -304,9 +295,7 @@ class CombatManager:
         # This check was added due to the pointer not falling off in time,
         # referencing an enemy that just died
         try:
-            selected_attack_target_guid = self.memory.read_uuid(
-                target_unique_id_base + 0x14
-            )
+            selected_attack_target_guid = self.memory.read_uuid(target_unique_id_base + 0x14)
         except Exception:
             selected_attack_target_guid = ""
 
@@ -338,9 +327,7 @@ class CombatManager:
         # This check was added due to the pointer not falling off in time,
         # referencing an enemy that just died
         try:
-            selected_skill_target_guid = self.memory.read_uuid(
-                target_unique_id_base + 0x14
-            )
+            selected_skill_target_guid = self.memory.read_uuid(target_unique_id_base + 0x14)
         except Exception:
             selected_skill_target_guid = ""
 
@@ -357,8 +344,7 @@ class CombatManager:
                     [self.current_encounter_base, 0x120, 0x0, 0x78, 0x10, 0x0],
                 )
 
-                controller = self.memory.read_string(
-                    combat_controller_ptr + 0x0, 25)
+                controller = self.memory.read_string(combat_controller_ptr + 0x0, 25)
                 match controller:
                     case s if s.startswith("FirstEncounter"):
                         self.combat_controller = CombatEncounter.FirstEncounter
@@ -389,7 +375,7 @@ class CombatManager:
             except Exception:
                 self.combat_controller = CombatEncounter.Basic
 
-    def read_projectile_is_current_player(self: Self) -> float:
+    def read_projectile_is_current_player(self: Self) -> bool:
         if self._should_update():
             try:
                 progress_ptr = self.memory.follow_pointer(
@@ -419,9 +405,7 @@ class CombatManager:
     def read_projectile_bounce_count(self: Self) -> int:
         if self._should_update():
             try:
-                progress_ptr = self.memory.follow_pointer(
-                    self.base, [0x168, 0x18, 0x20, 0x0]
-                )
+                progress_ptr = self.memory.follow_pointer(self.base, [0x168, 0x18, 0x20, 0x0])
 
                 return self.memory.read_int(progress_ptr + 0x15C)
 
@@ -433,9 +417,7 @@ class CombatManager:
     def read_projectile_hit_count(self: Self) -> int:
         if self._should_update():
             try:
-                progress_ptr = self.memory.follow_pointer(
-                    self.base, [0x168, 0x18, 0x20, 0x0]
-                )
+                progress_ptr = self.memory.follow_pointer(self.base, [0x168, 0x18, 0x20, 0x0])
 
                 return self.memory.read_int(progress_ptr + 0x158)
 
@@ -443,7 +425,7 @@ class CombatManager:
                 return 0
         return 0
 
-    def read_projectile_speed(self: Self) -> int:
+    def read_projectile_speed(self: Self) -> float:
         if self._should_update():
             try:
                 progress_ptr = self.memory.follow_pointer(
@@ -456,12 +438,10 @@ class CombatManager:
                 return 0.0
         return 0.0
 
-    def read_back_to_slot(self: Self) -> float:
+    def read_back_to_slot(self: Self) -> bool:
         if self._should_update():
             try:
-                back_to_slot_ptr = self.memory.follow_pointer(
-                    self.base, [0x168, 0x18, 0x20, 0x0]
-                )
+                back_to_slot_ptr = self.memory.follow_pointer(self.base, [0x168, 0x18, 0x20, 0x0])
                 # this is now actually finalHitDelayDone instead of moongirlBackToSlot
                 back_to_slot = self.memory.read_bool(back_to_slot_ptr + 0x160)
                 if back_to_slot:
@@ -475,8 +455,7 @@ class CombatManager:
     def _read_battle_commands(self: Self) -> None:
         if self._should_update():
             battle_command_selector = self.memory.follow_pointer(
-                self.base, [self.current_encounter_base,
-                            0x138, 0x50, 0x68, 0x0]
+                self.base, [self.current_encounter_base, 0x138, 0x50, 0x68, 0x0]
             )
             # Checks if we lost access to the selector pointer for a brief period as the UI changes.
             if battle_command_selector == self.NULL_POINTER:
@@ -489,8 +468,7 @@ class CombatManager:
                     # Checks an address to see if the battle command menu is visible
                     # and read the index for it if it is available, otherwise set it
                     # back to a NoneType for safety
-                    has_focus = self.memory.read_bool(
-                        battle_command_selector + 0x3C)
+                    has_focus = self.memory.read_bool(battle_command_selector + 0x3C)
 
                     self.battle_command_has_focus = has_focus
                     if has_focus:
@@ -514,8 +492,7 @@ class CombatManager:
     def _read_skill_commands(self: Self) -> None:
         if self._should_update():
             skill_command_selector = self.memory.follow_pointer(
-                self.base, [self.current_encounter_base,
-                            0x138, 0x50, 0x78, 0x0]
+                self.base, [self.current_encounter_base, 0x138, 0x50, 0x78, 0x0]
             )
             # Checks if we lost access to the selector pointer for a brief period as the UI changes.
             if skill_command_selector == self.NULL_POINTER:
@@ -531,11 +508,8 @@ class CombatManager:
                     # as it seems to lose its pointer quite often, especially when the
                     # item menu is open
                     # TODO(eein): Does the skill_command_selector apply to the items menu as well?
-                    has_focus = self.memory.read_bool(
-                        skill_command_selector + 0x3C)
-                    selected_item_index = self.memory.read_longlong(
-                        skill_command_selector + 0x40
-                    )
+                    has_focus = self.memory.read_bool(skill_command_selector + 0x3C)
+                    selected_item_index = self.memory.read_longlong(skill_command_selector + 0x40)
                     self.skill_command_has_focus = has_focus
                     self.skill_command_index = selected_item_index
                     if has_focus:
@@ -590,8 +564,7 @@ class CombatManager:
                 self.big_live_mana = 0
                 return
             if small_live_mana and big_live_mana:
-                self.small_live_mana = self.memory.read_int(
-                    small_live_mana + 0x18)
+                self.small_live_mana = self.memory.read_int(small_live_mana + 0x18)
                 self.big_live_mana = self.memory.read_int(big_live_mana + 0x18)
                 return
 
@@ -605,8 +578,7 @@ class CombatManager:
                 )
                 panel_count = self.memory.read_int(panel_count_ptr + 0x5C)
                 player_panels_list = self.memory.follow_pointer(
-                    self.base, [self.current_encounter_base,
-                                0x120, 0x98, 0x40, 0x0]
+                    self.base, [self.current_encounter_base, 0x120, 0x98, 0x40, 0x0]
                 )
             except Exception:
                 self.players = []
@@ -644,63 +616,49 @@ class CombatManager:
 
                     # Check if the character definition id is 0, and return as the
                     # character cannot be queried against
-                    character_definition_id = self.memory.read_longlong(
-                        item + 0x70)
+                    character_definition_id = self.memory.read_longlong(item + 0x70)
 
                     # If the character isn't loaded, ignore.
                     if character_definition_id == 0:
                         address += self.ITEM_OBJECT_OFFSET
                         continue
 
-                    dead_ptr = self.memory.follow_pointer(
-                        item, [0x68, 0x38, 0x0])
+                    dead_ptr = self.memory.follow_pointer(item, [0x68, 0x38, 0x0])
                     dead = self.memory.read_bool(dead_ptr + 0xD0)
 
                     # tracks timed attacks maybe
                     # timedAttackHandler -> trackingAfterHit
                     try:
-                        timed_attack_ptr = self.memory.follow_pointer(
-                            dead_ptr, [0x160, 0x0]
-                        )
-                        timed_attack_value = self.memory.read_bool(
-                            timed_attack_ptr + 0x3A
-                        )
+                        timed_attack_ptr = self.memory.follow_pointer(dead_ptr, [0x160, 0x0])
+                        timed_attack_value = self.memory.read_bool(timed_attack_ptr + 0x3A)
                     except Exception:
                         timed_attack_value = False
 
-                    definition_id_ptr = self.memory.follow_pointer(item, [
-                                                                   0x70, 0x0])
+                    definition_id_ptr = self.memory.follow_pointer(item, [0x70, 0x0])
                     # 4 Chars * 2 for utf
-                    definition_id = self.memory.read_string(
-                        definition_id_ptr + 0x14, 8)
+                    definition_id = self.memory.read_string(definition_id_ptr + 0x14, 8)
 
                     # Definition IDS are stored as some goofy serialized utf encoded string
                     # We just do our best with the values that are provided to
                     # Determine the character we are looking at
-                    character = PlayerPartyCharacter.parse_definition_id(
-                        definition_id)
+                    character = PlayerPartyCharacter.parse_definition_id(definition_id)
 
                     selected = self.memory.read_bool(item + 0x78)
-                    hp_text_field = self.memory.follow_pointer(
-                        item, [0x28, 0x0])
+                    hp_text_field = self.memory.follow_pointer(item, [0x28, 0x0])
                     current_hp = self.memory.read_int(hp_text_field + 0x58)
 
                     portrait = self.memory.follow_pointer(item, [0x68, 0x0])
                     enabled = self.memory.read_bool(portrait + 0x30)
 
-                    live_mana_handler = self.memory.follow_pointer(
-                        item, [0x68, 0x38, 0x148, 0x0]
-                    )
-                    mana_charge_count = self.memory.read_int(
-                        live_mana_handler + 0x58)
+                    live_mana_handler = self.memory.follow_pointer(item, [0x68, 0x38, 0x148, 0x0])
+                    mana_charge_count = self.memory.read_int(live_mana_handler + 0x58)
 
                     if selected:
                         selected_character = character
 
                     player = CombatPlayer()
 
-                    mp_text_field = self.memory.follow_pointer(
-                        item, [0x30, 0x0])
+                    mp_text_field = self.memory.follow_pointer(item, [0x30, 0x0])
 
                     current_mp = self.memory.read_int(mp_text_field + 0x58)
 
@@ -769,15 +727,11 @@ class CombatManager:
                         continue
 
                     current_hp = self.memory.read_int(item + 0x94)
-                    casting_data = self.memory.follow_pointer(
-                        items, [address, 0x80, 0x120, 0x0]
-                    )
+                    casting_data = self.memory.follow_pointer(items, [address, 0x80, 0x120, 0x0])
                     unique_id = self.memory.follow_pointer(
                         items, [address, 0x80, 0xF8, 0xF0, 0x18, 0x0]
                     )
-                    enemy_data = self.memory.follow_pointer(
-                        items, [address, 0x80, 0x108, 0x0]
-                    )
+                    enemy_data = self.memory.follow_pointer(items, [address, 0x80, 0x108, 0x0])
 
                     guid = self.memory.follow_pointer(enemy_data, [0x18, 0x0])
                     max_hp = self.memory.read_int(enemy_data + 0x20)
@@ -788,10 +742,8 @@ class CombatManager:
                     magic_defense = self.memory.read_int(enemy_data + 0x34)
                     enemy_guid = self.memory.read_guid(guid + 0x14)
                     enemy_unique_id = self.memory.read_uuid(unique_id + 0x14)
-                    turns_to_action = self.memory.read_short(
-                        casting_data + 0x24)
-                    total_spell_locks = self.memory.read_short(
-                        casting_data + 0x28)
+                    turns_to_action = self.memory.read_short(casting_data + 0x24)
+                    total_spell_locks = self.memory.read_short(casting_data + 0x28)
 
                     spell_locks: list[CombatSpellLock] = []
 
@@ -807,19 +759,14 @@ class CombatManager:
                             #   - 0x20 - Item[0]
                             #   - 0x28 - Item[1]
                             spell_locks_base = self.memory.follow_pointer(
-                                casting_data, [0x18, 0x10,
-                                               spell_locks_addr, 0x0]
+                                casting_data, [0x18, 0x10, spell_locks_addr, 0x0]
                             )
 
                             if spell_locks_base == 0x0:
                                 continue
 
-                            lock = self.memory.read_int(
-                                spell_locks_base + 0x40)
-                            spell_locks.append(
-                                CombatSpellLock(
-                                    damage_type=CombatDamageType(lock))
-                            )
+                            lock = self.memory.read_int(spell_locks_base + 0x40)
+                            spell_locks.append(CombatSpellLock(damage_type=CombatDamageType(lock)))
 
                             spell_locks_addr += self.ITEM_OBJECT_OFFSET
                     except Exception:


### PR DESCRIPTION
- Adds boosted attacks - boosted attacks will just be `value = value * boost + 1 for now` in utility.
- Adds context for setting priority targets to controllers
- adds target selection to utility
- reverts moonerang position value (still needs to be fixed)
- generates appraisals for all targets
- filters appraisals if health == 0 (elder mist and other fights with dead parts)
- moonerang now considers dead targets when calculating its 1 target requirement - this is temporary.
- extract _read_current_target in combat manager to get actual targets.. needs more testing