### PR TITLE
Combat logging tweak

### DIFF
--- a/engine/combat/appraisals/basic_attack.py
+++ b/engine/combat/appraisals/basic_attack.py
@@ -16,6 +16,9 @@ class BasicAttack(SoSAppraisal):
         self: Self, timing_type: SoSTimingType = SoSTimingType.OneHit, boost: int = 0
     ) -> None:
         super().__init__(
-            boost=boost, timing_type=timing_type, battle_command=SoSBattleCommand.Attack
+            name="Attack",
+            boost=boost,
+            timing_type=timing_type,
+            battle_command=SoSBattleCommand.Attack,
         )
         self.target_type = SoSTargetType.Enemy

--- a/engine/combat/appraisals/valere/crescent_arc.py
+++ b/engine/combat/appraisals/valere/crescent_arc.py
@@ -20,7 +20,7 @@ class CrescentArc(SoSAppraisal):
         boost: int = 0,
     ) -> None:
         super().__init__(
-            name="Cresent Arc",
+            name="Crescent Arc",
             boost=boost,
             timing_type=timing_type,
             battle_command=SoSBattleCommand.Skill,

--- a/engine/combat/appraisals/valere/crescent_arc.py
+++ b/engine/combat/appraisals/valere/crescent_arc.py
@@ -20,7 +20,10 @@ class CrescentArc(SoSAppraisal):
         boost: int = 0,
     ) -> None:
         super().__init__(
-            boost=boost, timing_type=timing_type, battle_command=SoSBattleCommand.Skill
+            name="Cresent Arc",
+            boost=boost,
+            timing_type=timing_type,
+            battle_command=SoSBattleCommand.Skill,
         )
         self.value = value
         self.target_type = SoSTargetType.Enemy

--- a/engine/combat/appraisals/valere/moonerang.py
+++ b/engine/combat/appraisals/valere/moonerang.py
@@ -26,7 +26,10 @@ class Moonerang(SoSAppraisal):
         boost: int = 0,
     ) -> None:
         super().__init__(
-            boost=boost, timing_type=timing_type, battle_command=SoSBattleCommand.Skill
+            name="Moonerang",
+            boost=boost,
+            timing_type=timing_type,
+            battle_command=SoSBattleCommand.Skill,
         )
         self.value = value
         self.battle_command_targeting_type = SoSBattleCommand.Attack

--- a/engine/combat/appraisals/zale/sunball.py
+++ b/engine/combat/appraisals/zale/sunball.py
@@ -48,5 +48,5 @@ class Sunball(SoSAppraisal):
             sos_ctrl().toggle_confirm(True)
             if self.ability_time <= datetime.utcnow():
                 sos_ctrl().toggle_confirm(False)
-                logger.debug("Executing Timing Attack")
+                logger.debug(f"Executing Timing Attack, Charge ({self.name})")
                 self.step = SoSAppraisalStep.ActionComplete

--- a/engine/combat/appraisals/zale/sunball.py
+++ b/engine/combat/appraisals/zale/sunball.py
@@ -24,7 +24,10 @@ class Sunball(SoSAppraisal):
         boost: int = 0,
     ) -> None:
         super().__init__(
-            boost=boost, timing_type=timing_type, battle_command=SoSBattleCommand.Skill
+            name="Sunball",
+            boost=boost,
+            timing_type=timing_type,
+            battle_command=SoSBattleCommand.Skill,
         )
         self.value = value
         self.target_type = SoSTargetType.Enemy

--- a/engine/combat/utility/core/action.py
+++ b/engine/combat/utility/core/action.py
@@ -22,3 +22,6 @@ class Action:
 
     def execute(self: Self) -> None:
         pass
+
+    def __repr__(self: Self) -> str:
+        return f"{self.consideration}->{self.appraisal}"

--- a/engine/combat/utility/core/appraisal.py
+++ b/engine/combat/utility/core/appraisal.py
@@ -5,7 +5,8 @@ logger = logging.getLogger(__name__)
 
 
 class Appraisal:
-    def __init__(self: Self, value: int = 0) -> None:
+    def __init__(self: Self, name: str, value: int = 0) -> None:
+        self.name: str = name
         self.value: int = value
         self.target: str = None
         self.complete: bool = False
@@ -13,3 +14,6 @@ class Appraisal:
     def execute(self: Self) -> None:
         logger.debug("No appraiser execution defined.")
         logger.debug("Please ensure your Appraisal implements the execute() function")
+
+    def __repr__(self: Self) -> str:
+        return self.name

--- a/engine/combat/utility/sos_appraisal.py
+++ b/engine/combat/utility/sos_appraisal.py
@@ -140,7 +140,7 @@ class SoSAppraisal(Appraisal):
             sos_ctrl().dpad.tap_down()
         else:
             self.step = SoSAppraisalStep.Boost
-            logger.debug(f"Selecting Battle Command: {self.battle_command.name}")
+            # logger.debug(f"Selecting Battle Command: {self.battle_command.name}")
 
     def execute_boost(self: Self) -> None:
         # TODO(eein): Check if theres a flag that shows when live mana is available and use
@@ -180,7 +180,7 @@ class SoSAppraisal(Appraisal):
             # set the character here for use later - since it drops from memory
             self.character = self.combat_manager.selected_character
             logger.debug(f"Confirmed Battle Command: {self.battle_command.name}")
-            logger.debug(f"Entering step: {self.step.name}")
+            # logger.debug(f"Entering step: {self.step.name}")
 
     def execute_selecting_skill(self: Self) -> None:
         if (
@@ -191,7 +191,7 @@ class SoSAppraisal(Appraisal):
             sos_ctrl().dpad.tap_down()
         else:
             self.step = SoSAppraisalStep.ConfirmSkill
-            logger.debug(f"Selecting Battle Skill: {self.name}")
+            # logger.debug(f"Selecting Battle Skill: {self.name}")
 
     def execute_confirm_skill(self: Self) -> None:
         if (
@@ -224,7 +224,7 @@ class SoSAppraisal(Appraisal):
             and self.combat_manager.selected_character != PlayerPartyCharacter.NONE
         ):
             self.step = SoSAppraisalStep.ConfirmEnemySequence
-            logger.debug(f"Selected Target {self.target}")
+            # logger.debug(f"Selected Target {self.target}")
             return
         # logger.warn("Enemy Target Not Valid, moving cursor")
         sos_ctrl().dpad.tap_right()
@@ -242,7 +242,7 @@ class SoSAppraisal(Appraisal):
             sos_ctrl().confirm()
         else:
             self.step = SoSAppraisalStep.TimingSequence
-            logger.debug(f"Confirmed Target  {self.target}")
+            # logger.debug(f"Confirmed Target {self.target}")
 
     def execute_timing_sequence(self: Self) -> None:
         match self.timing_type:

--- a/engine/combat/utility/sos_appraisal.py
+++ b/engine/combat/utility/sos_appraisal.py
@@ -59,11 +59,12 @@ class SoSAppraisal(Appraisal):
 
     def __init__(
         self: Self,
+        name: str,
         timing_type: SoSTimingType = SoSTimingType.NONE,
         boost: int = 0,
         battle_command: SoSBattleCommand = SoSBattleCommand.Attack,
     ) -> None:
-        super().__init__()
+        super().__init__(name=name)
 
         self.combat_manager = combat_manager_handle()
         self.complete = False
@@ -81,6 +82,22 @@ class SoSAppraisal(Appraisal):
         self.cost = 0
         self.boost = boost
         self.enemy_targeting_failures = 0
+
+    def __repr__(self: Self) -> str:
+        name = f"[{self.name}]" if self.battle_command != SoSBattleCommand.Attack else ""
+        target = ""
+        if self.target is not None:
+            enemy_name = ""
+            enemy_idx = 0
+            for idx, enemy in enumerate(self.combat_manager.enemies):
+                if self.target is enemy.unique_id:
+                    enemy_idx = idx
+                    enemy_name = enemy.name
+            if enemy_name != "":
+                target = f" (target = {enemy_name}[{enemy_idx}])"
+            else:
+                target = f" (target = {self.target})"
+        return f"{self.battle_command.name}{name}{target}"
 
     def execute(self: Self) -> None:
         """Select the step to perform based on the current step."""
@@ -106,7 +123,7 @@ class SoSAppraisal(Appraisal):
             case SoSAppraisalStep.ActionComplete:
                 self.execute_action_complete()
             case _:
-                logger.debug("Appraisal Step OUT OF BOUNDS")
+                logger.error(f"Appraisal Step {self.step} OUT OF BOUNDS")
 
     def execute_selecting_command(self: Self) -> None:
         """
@@ -129,12 +146,12 @@ class SoSAppraisal(Appraisal):
         # TODO(eein): Check if theres a flag that shows when live mana is available and use
         # that to guard this function as well
         if self.boost > 0:
-            logger.debug(f"Boosting: {self.battle_command.name} {self.boost} times")
+            logger.debug(f"Boosting: {self.name} {self.boost} times")
             sos_ctrl().toggle_boost(True)
             time.sleep(0.5)
 
             for boost in range(self.boost):
-                logger.debug(f"Triggering Boost: {boost + 1}")
+                logger.debug(f"  Triggering Boost: {boost + 1}")
                 sos_ctrl().confirm(tapping=True)
 
             sos_ctrl().toggle_boost(False)
@@ -158,7 +175,7 @@ class SoSAppraisal(Appraisal):
                 case SoSBattleCommand.Item:
                     self.step = SoSAppraisalStep.SelectingSkill
                 case _:
-                    logger.debug("Invalid Battle Command")
+                    logger.error(f"Invalid Battle Command: {self.battle_command}")
 
             # set the character here for use later - since it drops from memory
             self.character = self.combat_manager.selected_character
@@ -174,7 +191,7 @@ class SoSAppraisal(Appraisal):
             sos_ctrl().dpad.tap_down()
         else:
             self.step = SoSAppraisalStep.ConfirmSkill
-            logger.debug(f"Selecting Battle Command: {self.battle_command.name}")
+            logger.debug(f"Selecting Battle Skill: {self.name}")
 
     def execute_confirm_skill(self: Self) -> None:
         if (
@@ -185,17 +202,19 @@ class SoSAppraisal(Appraisal):
             sos_ctrl().confirm()
             # Attack skips to selecting enemy sequence
             match self.battle_command:
+                # TODO(orkaboy): This is technically wrong; healing combos and skills like
+                # TODO(orkaboy): Zale's heal would target a player character
                 case SoSBattleCommand.Skill | SoSBattleCommand.Combo:
                     self.step = SoSAppraisalStep.SelectingEnemySequence
                 case SoSBattleCommand.Item:
                     self.step = SoSAppraisalStep.SelectingPlayerSequence
                 case _:
-                    logger.debug("Invalid Skill Command")
+                    logger.error("Invalid Skill Command")
 
             # set the character here for use later - since it drops from memory
 
-            logger.debug(f"Confirmed Skill Command: {self.battle_command.name}")
-            logger.debug(f"Entering step: {self.step.name}")
+            logger.debug(f"Confirmed Skill Command: {self.name}")
+            # logger.debug(f"Entering step: {self.step.name}")
 
     def execute_selecting_enemy_sequence(self: Self) -> None:
         if (
@@ -205,9 +224,9 @@ class SoSAppraisal(Appraisal):
             and self.combat_manager.selected_character != PlayerPartyCharacter.NONE
         ):
             self.step = SoSAppraisalStep.ConfirmEnemySequence
-            logger.debug("Selected Target")
+            logger.debug(f"Selected Target {self.target}")
             return
-        logger.warn("Enemy Target Not Valid, moving cursor")
+        # logger.warn("Enemy Target Not Valid, moving cursor")
         sos_ctrl().dpad.tap_right()
         # TODO(eein): This will be improved when we have a better way to
         # detect who we are targeting. For now we just fail after 6 failures
@@ -219,11 +238,11 @@ class SoSAppraisal(Appraisal):
 
     def execute_confirm_enemy_sequence(self: Self) -> None:
         if self.combat_manager.selected_character != PlayerPartyCharacter.NONE:
-            logger.debug("Confirming Enemy")
+            logger.debug(f"Confirming Enemy {self.target}")
             sos_ctrl().confirm()
         else:
             self.step = SoSAppraisalStep.TimingSequence
-            logger.debug("Confirmed Target")
+            logger.debug(f"Confirmed Target  {self.target}")
 
     def execute_timing_sequence(self: Self) -> None:
         match self.timing_type:
@@ -231,7 +250,7 @@ class SoSAppraisal(Appraisal):
                 # wait for timing and press button
                 # need a way to bail out if missed timing
                 if self.is_player_timed_attack_ready():
-                    logger.debug("Executing Timing Attack")
+                    logger.debug(f"Executing Timing Attack, Tap ({self.name})")
                     sos_ctrl().confirm()
                     self.step = SoSAppraisalStep.ActionComplete
             case SoSTimingType.Charge:
@@ -240,14 +259,14 @@ class SoSAppraisal(Appraisal):
                 sos_ctrl().toggle_confirm(True)
                 if self.is_player_timed_attack_ready():
                     sos_ctrl().toggle_confirm(False)
-                    logger.debug("Executing Timing Attack")
+                    logger.debug(f"Executing Timing Attack, Charge ({self.name})")
                     self.step = SoSAppraisalStep.ActionComplete
             case _:
                 self.step = SoSAppraisalStep.ActionComplete
 
     def execute_action_complete(self: Self) -> None:
         self.complete = True
-        # logger.debug("Action Complete")
+        logger.debug("Action Complete")
 
     def _enemy_targeted(self: Self) -> bool:
         # If we are doing some custom controller stuff that doesn't need a target, just return True

--- a/engine/combat/utility/sos_consideration.py
+++ b/engine/combat/utility/sos_consideration.py
@@ -6,8 +6,8 @@ from engine.combat.appraisals.basic_attack import BasicAttack
 from engine.combat.appraisals.valere import CrescentArc, Moonerang
 from engine.combat.appraisals.zale import Sunball
 from engine.combat.utility.core.action import Action
-from engine.combat.utility.core.appraisal import Appraisal
 from engine.combat.utility.core.consideration import Consideration
+from engine.combat.utility.sos_appraisal import SoSAppraisal
 from memory import CombatPlayer, PlayerPartyCharacter, combat_manager_handle
 
 combat_manager = combat_manager_handle()
@@ -18,12 +18,12 @@ class SoSConsideration(Consideration):
         self.actor = actor
         super().__init__()
 
-    def generate_appraisals(self: Self) -> list[Appraisal]:
+    def generate_appraisals(self: Self) -> list[SoSAppraisal]:
         """Generate a list of appraisals for a character."""
         appraisals = self._default_appraisals() + self._character_appraisals()
         return list(filter(self._has_resources_for_appraisal, appraisals))
 
-    def _has_resources_for_appraisal(self: Self, appraisal: Appraisal) -> bool:
+    def _has_resources_for_appraisal(self: Self, appraisal: SoSAppraisal) -> bool:
         return appraisal.has_resources(self.actor)
 
     def valid(self: Self, selected_character: PlayerPartyCharacter, action: Action) -> bool:
@@ -35,11 +35,11 @@ class SoSConsideration(Consideration):
     def on_selected_character(
         self: Self, selected_character: PlayerPartyCharacter, action: Action
     ) -> bool:
-        actor: CombatPlayer = action.consideration.actor
-        return selected_character is actor.character
+        consideration: Self = action.consideration
+        return selected_character is consideration.actor.character
 
     # TODO(eein): Add item appraisals + dont use physical attacks and the appraisal value
-    def _default_appraisals(self: Self) -> list[Appraisal]:
+    def _default_appraisals(self: Self) -> list[SoSAppraisal]:
         """Generate default appraisals generic to every consideration."""
         basic_attack = BasicAttack()
         basic_attack.value = self.actor.physical_attack
@@ -47,7 +47,7 @@ class SoSConsideration(Consideration):
         return [basic_attack]
 
     # TODO(eein): Calculate appraisals based on skill/combo availability
-    def _character_appraisals(self: Self) -> list[Appraisal]:
+    def _character_appraisals(self: Self) -> list[SoSAppraisal]:
         match self.actor.character:
             case PlayerPartyCharacter.Zale:
                 return [Sunball(value=100)]
@@ -69,7 +69,7 @@ class SoSConsideration(Consideration):
         actions = []
         # TODO(eein): To give value to boosted appraisals we will just multiply the value by
         # the boost for now, we can modify this when we work further on utility.
-        boosted_appraisals = []
+        boosted_appraisals: list[SoSAppraisal] = []
         for appraisal in self.appraisals:
             boosts_available = round(combat_manager.small_live_mana / 5)
             if boosts_available == 0:
@@ -77,7 +77,7 @@ class SoSConsideration(Consideration):
                 continue
 
             for boost in range(0, boosts_available + 1):
-                new_appraisal = copy.copy(appraisal)
+                new_appraisal: SoSAppraisal = copy.copy(appraisal)
                 new_appraisal.boost = boost
                 new_appraisal.value = new_appraisal.value * (boost + 1)
                 boosted_appraisals.append(new_appraisal)
@@ -97,3 +97,6 @@ class SoSConsideration(Consideration):
         This should select the character based on the memory. Just pressing left for now.
         """
         sos_ctrl().dpad.tap_left()
+
+    def __repr__(self: Self) -> str:
+        return self.actor.character.name

--- a/engine/combat/utility/sos_reasoner.py
+++ b/engine/combat/utility/sos_reasoner.py
@@ -33,12 +33,12 @@ class SoSReasoner(Reasoner):
 
     def _select_action(self: Self) -> Action:
         """Calculate value for each consideration and return the highest value action."""
-        actions = []
+        actions: list[Action] = []
         for consideration in self.considerations:
             calculated_actions = consideration.calculate_actions()
             actions.extend(calculated_actions)
 
-        if actions == []:
+        if not actions:
             return None
 
         # sort and return the results by their value in desc order
@@ -48,10 +48,10 @@ class SoSReasoner(Reasoner):
         actions = self._filter_disabled_enemies(actions)
 
         # if we have priority targets, then filter out any actions that don't target them
-        if self.reasoner_execution_context.priority_targets is not []:
+        if self.reasoner_execution_context.priority_targets != []:
             actions = self._filter_priority_targets(actions)
 
-        if len(actions) == 0:
+        if not actions:
             return None
         return actions[0]
 


### PR DESCRIPTION
Made some adjustments to how debug printouts are made in the combat controller.

Example output:
![bild](https://github.com/shenef/SoS-TAS/assets/1805679/a55f2d91-a575-4906-b67f-bebc28dd7864)

Known limitations: Instead of spamming the enemy cast skill when trying to block, the TAS will only print the name once. Since there's no way of detecting multiple casts in a row atm, only the first ability cast will be printed.