### PR TITLE
SeqTextCrawl node

### DIFF
--- a/engine/seq/__init__.py
+++ b/engine/seq/__init__.py
@@ -12,7 +12,7 @@ from engine.seq.interact import (
     SeqSkipUntilIdle,
     SeqTapDown,
 )
-from engine.seq.log import SeqDebug, SeqLog
+from engine.seq.log import SeqDebug, SeqLog, SeqTextCrawl
 from engine.seq.move import (
     CancelMove,
     Graplou,
@@ -46,6 +46,7 @@ __all__ = [
     "SequencerEngine",
     "SeqDebug",
     "SeqLog",
+    "SeqTextCrawl",
     "SeqBase",
     "SeqList",
     "SeqIf",

--- a/engine/seq/log.py
+++ b/engine/seq/log.py
@@ -4,6 +4,7 @@
 import logging
 from typing import Self
 
+from control import sos_ctrl
 from engine.seq.base import SeqBase
 
 logger = logging.getLogger(__name__)
@@ -13,6 +14,7 @@ class SeqLog(SeqBase):
     """Print to the log using the `info` log level."""
 
     def __init__(self: Self, name: str, text: str) -> None:
+        """Initialize a SeqLog node."""
         self.text = text
         super().__init__(name)
 
@@ -26,6 +28,7 @@ class SeqDebug(SeqBase):
     """Print to the log using the `debug` log level."""
 
     def __init__(self: Self, name: str, text: str) -> None:
+        """Initialize a SeqDebug node."""
         self.text = text
         super().__init__(name)
 
@@ -33,3 +36,49 @@ class SeqDebug(SeqBase):
         """Print text to log."""
         logging.getLogger(self.name).debug(self.text)
         return True
+
+
+class SeqTextCrawl(SeqBase):
+    """
+    Print text over time in the TAS GUI, optionally skipping cutscenes.
+
+    This can be used to show a bunch of text to a viewer.
+    """
+
+    def __init__(
+        self: Self, name: str, text_nodes: list[tuple[str, float]], skip_cutscene: bool = True
+    ) -> None:
+        """Initialize a SeqTextCrawl node."""
+        super().__init__(name)
+        self.skip_cutscene = skip_cutscene
+        self.step = 0
+        self.timer = 0.0
+        self.text_nodes = text_nodes
+
+    def execute(self: Self, delta: float) -> bool:
+        ctrl = sos_ctrl()
+        if self.step >= len(self.text_nodes):
+            ctrl.toggle_turbo(state=False)
+            ctrl.toggle_confirm(state=False)
+            ctrl.toggle_cancel(state=False)
+            return True
+        # Get the current text node
+        _, cur_timeout = self.text_nodes[self.step]
+
+        if self.skip_cutscene:
+            ctrl.toggle_turbo(state=True)
+            ctrl.toggle_confirm(state=True)
+            ctrl.toggle_cancel(state=True)
+
+        # Increase the timer and go to next step
+        self.timer += delta
+        if self.timer >= cur_timeout:
+            self.timer = 0.0
+            self.step = self.step + 1
+        return False
+
+    def __repr__(self: Self) -> str:
+        if self.step >= len(self.text_nodes):
+            return ""
+        cur_text, _ = self.text_nodes[self.step]
+        return f"\n{cur_text}\n"


### PR DESCRIPTION
Added a new sequencer node that can be used to show a text crawl (a list of string/timeout tuples). It will show the text of the current text for the specified timeout in the TAS GUI window, then go to the next text. Optionally, it can hold the skip cutscene buttons.

The idea is that this node can be used to show some interesting text during long cutscene sequences.