### PR TITLE
Inventory memory

### DIFF
--- a/GUI/GUI.py
+++ b/GUI/GUI.py
@@ -17,7 +17,7 @@ from imgui_bundle import imgui
 from memory import (
     boat_manager_handle,
     combat_manager_handle,
-    inventory_manager_handle,
+    inventory_manager_mem_handle,
     level_manager_handle,
     level_up_manager_handle,
     mem_handle,
@@ -81,7 +81,7 @@ def update_memory() -> None:
             level_up_manager_handle().update()
             combat_manager_handle().update()
             new_dialog_manager_handle().update()
-            inventory_manager_handle().update()
+            inventory_manager_mem_handle().update()
             if "WorldMap" in scene_name:
                 boat_manager_handle().update()
 

--- a/GUI/GUI.py
+++ b/GUI/GUI.py
@@ -17,6 +17,7 @@ from imgui_bundle import imgui
 from memory import (
     boat_manager_handle,
     combat_manager_handle,
+    currency_manager_handle,
     inventory_manager_mem_handle,
     level_manager_handle,
     level_up_manager_handle,
@@ -82,6 +83,7 @@ def update_memory() -> None:
             combat_manager_handle().update()
             new_dialog_manager_handle().update()
             inventory_manager_mem_handle().update()
+            currency_manager_handle().update()
             if "WorldMap" in scene_name:
                 boat_manager_handle().update()
 

--- a/GUI/tools/inventory_helper.py
+++ b/GUI/tools/inventory_helper.py
@@ -6,10 +6,12 @@ from imgui_bundle import imgui
 from engine.inventory import ItemType, get_inventory_manager
 from GUI.GUI import LayoutHelper, Window
 from GUI.menu import Menu
+from memory.currency_manager import currency_manager_handle
 
 logger = logging.getLogger(__name__)
 
 inventory_manager = get_inventory_manager()
+currency_manager = currency_manager_handle()
 
 
 class InventoryHelper(Menu):
@@ -23,7 +25,7 @@ class InventoryHelper(Menu):
         imgui.set_window_size(imgui.ImVec2(240, 410), cond=imgui.Cond_.first_use_ever)
         imgui.set_window_collapsed(1, cond=imgui.Cond_.once)
 
-        imgui.text(f"Money: {inventory_manager.money}")
+        imgui.text(f"Money: {currency_manager.money}")
         LayoutHelper.add_spacer()
 
         for item_type in [

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -9,6 +9,7 @@ from memory.combat_manager import (
     combat_manager_handle,
 )
 from memory.core import SoSMemory, mem_handle
+from memory.currency_manager import currency_manager_handle
 from memory.inventory_manager_mem import inventory_manager_mem_handle
 from memory.level_manager import level_manager_handle
 from memory.level_up_manager import (
@@ -37,6 +38,7 @@ __all__ = [
     "LevelUpUpgrade",
     "LevelUpUpgradeType",
     "level_manager_handle",
+    "currency_manager_handle",
     "new_dialog_manager_handle",
     "player_party_manager_handle",
     "time_of_day_manager_handle",

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -9,7 +9,7 @@ from memory.combat_manager import (
     combat_manager_handle,
 )
 from memory.core import SoSMemory, mem_handle
-from memory.inventory_manager import inventory_manager_handle
+from memory.inventory_manager_mem import inventory_manager_mem_handle
 from memory.level_manager import level_manager_handle
 from memory.level_up_manager import (
     LevelUpManager,
@@ -41,7 +41,7 @@ __all__ = [
     "player_party_manager_handle",
     "time_of_day_manager_handle",
     "title_sequence_manager_handle",
-    "inventory_manager_handle",
+    "inventory_manager_mem_handle",
     "PlayerPartyCharacter",
     "PlayerMovementState",
     "TitleCursorPosition",

--- a/memory/currency_manager.py
+++ b/memory/currency_manager.py
@@ -1,0 +1,59 @@
+import logging
+from typing import Self
+
+from memory.core import mem_handle
+
+logger = logging.getLogger(__name__)
+
+
+class CurrencyManager:
+    def __init__(self: Self) -> None:
+        """Initialize a new CurrencyManager object."""
+        self.memory = mem_handle()
+        self.base = None
+        self.currency = 0
+
+    def update(self: Self) -> None:
+        if self.memory.ready_for_updates:
+            try:
+                if self.base is None:
+                    singleton_ptr = self.memory.get_singleton_by_class_name("CurrencyManager")
+                    if singleton_ptr is None:
+                        return
+
+                    self.base = self.memory.get_class_base(singleton_ptr)
+                    if self.base == 0x0:
+                        return
+                    pass
+
+                else:
+                    self._read_currencies()
+                    pass
+            except Exception as _e:
+                logger.debug(f"CurrencyManager Reloading {type(_e)}")
+                self.__init__()
+
+    def _read_currencies(self: Self) -> None:
+        """
+        Read the currencies from the inventory manager.
+
+        Only one currency actually exists, but the manager has a list of currencies.
+
+        For now, just check the first one.
+        """
+        if self.memory.ready_for_updates:
+            try:
+                # currencyQuantities -> _entries + 0x20 for first entry
+                ptr = self.memory.follow_pointer(self.base, [0x28, 0x18, 0x0])
+                if ptr:
+                    self.currency = self.memory.read_int(ptr + 0x30)
+
+            except Exception:
+                self.currency = 0
+
+
+_currency_manager_mem = CurrencyManager()
+
+
+def currency_manager_handle() -> CurrencyManager:
+    return _currency_manager_mem

--- a/memory/currency_manager.py
+++ b/memory/currency_manager.py
@@ -11,7 +11,7 @@ class CurrencyManager:
         """Initialize a new CurrencyManager object."""
         self.memory = mem_handle()
         self.base = None
-        self.currency = 0
+        self.money = 0
 
     def update(self: Self) -> None:
         if self.memory.ready_for_updates:
@@ -46,10 +46,10 @@ class CurrencyManager:
                 # currencyQuantities -> _entries + 0x20 for first entry
                 ptr = self.memory.follow_pointer(self.base, [0x28, 0x18, 0x0])
                 if ptr:
-                    self.currency = self.memory.read_int(ptr + 0x30)
+                    self.money = self.memory.read_int(ptr + 0x30)
 
             except Exception:
-                self.currency = 0
+                self.money = 0
 
 
 _currency_manager_mem = CurrencyManager()

--- a/memory/inventory_manager.py
+++ b/memory/inventory_manager.py
@@ -1,53 +1,74 @@
+import logging
 from typing import Self
 
 from memory.core import mem_handle
 
+logger = logging.getLogger(__name__)
 
-class InventoryManagerMem:
+
+class ItemReference:
+    def __init__(self: Self, guid: str, quantity: int) -> None:
+        self.guid = guid
+        self.quantity = quantity
+
+
+class InventoryManager:
+    INVENTORY_ITEM_OFFSET = 0x18
+
     def __init__(self: Self) -> None:
         """Initialize a new InventoryManagerMem object."""
         self.memory = mem_handle()
         self.base = None
         # TODO(orkaboy): Declare data fields
+        self.items = []
 
     def update(self: Self) -> None:
         if self.memory.ready_for_updates:
             try:
                 if self.base is None:
-                    # singleton_ptr = self.memory.get_singleton_by_class_name("BoatManager")
-                    # if singleton_ptr is None:
-                    #     return
+                    singleton_ptr = self.memory.get_singleton_by_class_name("InventoryManager")
+                    if singleton_ptr is None:
+                        return
 
-                    # self.base = self.memory.get_class_base(singleton_ptr)
-                    # if self.base == 0x0:
-                    #     return
+                    self.base = self.memory.get_class_base(singleton_ptr)
+                    if self.base == 0x0:
+                        return
                     pass
 
                 else:
                     # TODO(orkaboy): Update fields
-                    # self._read_position()
+                    self._read_items()
                     pass
             except Exception as _e:
-                # logger.debug(f"BoatManager Reloading {type(_e)}")
+                logger.debug(f"InventoryManager Reloading {type(_e)}")
                 self.__init__()
 
-    # def _read_position(self: Self) -> None:
-    #     if self.memory.ready_for_updates:
-    #         # (BoatInstance) k__BackingField -> boatController -> currentTargetPosition
-    #         ptr = self.memory.follow_pointer(self.base, [0x40, 0x40, 0x84])
-    #         if ptr:
-    #             x = self.memory.read_float(ptr + 0x0)
-    #             y = self.memory.read_float(ptr + 0x4)
-    #             z = self.memory.read_float(ptr + 0x8)
+    def _read_items(self: Self) -> None:
+        items = []
+        address = 0x0
+        if self.memory.ready_for_updates:
+            try:
+                # ownedInventoryItems -> dictionary -> _entries + 0x20 for first entry
+                while True:
+                    ptr = self.memory.follow_pointer(self.base, [0x70, 0x20, 0x18, 0x20 + address])
+                    if ptr:
+                        guid_ptr = self.memory.follow_pointer(ptr, [0x8, 0x0])
+                        if guid_ptr == 0x0:
+                            break
+                        guid = self.memory.read_guid(guid_ptr + 0x14)
+                        quantity = self.memory.read_int(ptr + 0x10)
+                        items.append(ItemReference(guid, quantity))
+                        address += self.INVENTORY_ITEM_OFFSET
+                    else:
+                        break
+            except Exception:
+                self.items = []
+                return
+        self.items = items
 
-    #             self.position = Vec3(x, y, z)
-    #             return
 
-    #     self.position = Vec3(None, None, None)
+_inventory_manager_mem = InventoryManager()
 
 
-_inventory_manager_mem = InventoryManagerMem()
-
-
-def inventory_manager_handle() -> InventoryManagerMem:
+def inventory_manager_handle() -> InventoryManager:
     return _inventory_manager_mem

--- a/memory/inventory_manager_mem.py
+++ b/memory/inventory_manager_mem.py
@@ -19,13 +19,15 @@ class InventoryManagerMem:
         """Initialize a new InventoryManagerMem object."""
         self.memory = mem_handle()
         self.base = None
-        self.items = []
+        self.items: list[ItemReference] = []
 
     def update(self: Self) -> None:
         if self.memory.ready_for_updates:
             try:
                 if self.base is None:
-                    singleton_ptr = self.memory.get_singleton_by_class_name("InventoryManager")
+                    singleton_ptr = self.memory.get_singleton_by_class_name(
+                        "InventoryManager"
+                    )
                     if singleton_ptr is None:
                         return
 
@@ -42,7 +44,7 @@ class InventoryManagerMem:
                 self.__init__()
 
     def _read_items(self: Self) -> None:
-        items = []
+        items: list[ItemReference] = []
         address = 0x0
         if self.memory.ready_for_updates:
             try:
@@ -50,7 +52,9 @@ class InventoryManagerMem:
                 count_ptr = self.memory.follow_pointer(self.base, [0x70, 0x20, 0x20])
                 count = self.memory.read_int(count_ptr)
                 for _i in range(count):
-                    ptr = self.memory.follow_pointer(self.base, [0x70, 0x20, 0x18, 0x20 + address])
+                    ptr = self.memory.follow_pointer(
+                        self.base, [0x70, 0x20, 0x18, 0x20 + address]
+                    )
                     if ptr:
                         guid_ptr = self.memory.follow_pointer(ptr, [0x8, 0x0])
                         if guid_ptr == 0x0:

--- a/memory/inventory_manager_mem.py
+++ b/memory/inventory_manager_mem.py
@@ -47,7 +47,9 @@ class InventoryManagerMem:
         if self.memory.ready_for_updates:
             try:
                 # ownedInventoryItems -> dictionary -> _entries + 0x20 for first entry
-                while True:
+                count_ptr = self.memory.follow_pointer(self.base, [0x70, 0x20, 0x20])
+                count = self.memory.read_int(count_ptr)
+                for _i in range(count):
                     ptr = self.memory.follow_pointer(self.base, [0x70, 0x20, 0x18, 0x20 + address])
                     if ptr:
                         guid_ptr = self.memory.follow_pointer(ptr, [0x8, 0x0])

--- a/memory/inventory_manager_mem.py
+++ b/memory/inventory_manager_mem.py
@@ -25,9 +25,7 @@ class InventoryManagerMem:
         if self.memory.ready_for_updates:
             try:
                 if self.base is None:
-                    singleton_ptr = self.memory.get_singleton_by_class_name(
-                        "InventoryManager"
-                    )
+                    singleton_ptr = self.memory.get_singleton_by_class_name("InventoryManager")
                     if singleton_ptr is None:
                         return
 
@@ -52,9 +50,7 @@ class InventoryManagerMem:
                 count_ptr = self.memory.follow_pointer(self.base, [0x70, 0x20, 0x20])
                 count = self.memory.read_int(count_ptr)
                 for _i in range(count):
-                    ptr = self.memory.follow_pointer(
-                        self.base, [0x70, 0x20, 0x18, 0x20 + address]
-                    )
+                    ptr = self.memory.follow_pointer(self.base, [0x70, 0x20, 0x18, 0x20 + address])
                     if ptr:
                         guid_ptr = self.memory.follow_pointer(ptr, [0x8, 0x0])
                         if guid_ptr == 0x0:

--- a/memory/inventory_manager_mem.py
+++ b/memory/inventory_manager_mem.py
@@ -12,14 +12,13 @@ class ItemReference:
         self.quantity = quantity
 
 
-class InventoryManager:
+class InventoryManagerMem:
     INVENTORY_ITEM_OFFSET = 0x18
 
     def __init__(self: Self) -> None:
         """Initialize a new InventoryManagerMem object."""
         self.memory = mem_handle()
         self.base = None
-        # TODO(orkaboy): Declare data fields
         self.items = []
 
     def update(self: Self) -> None:
@@ -36,7 +35,6 @@ class InventoryManager:
                     pass
 
                 else:
-                    # TODO(orkaboy): Update fields
                     self._read_items()
                     pass
             except Exception as _e:
@@ -67,8 +65,8 @@ class InventoryManager:
         self.items = items
 
 
-_inventory_manager_mem = InventoryManager()
+_inventory_manager_mem = InventoryManagerMem()
 
 
-def inventory_manager_handle() -> InventoryManager:
+def inventory_manager_mem_handle() -> InventoryManagerMem:
     return _inventory_manager_mem


### PR DESCRIPTION
- adds InventoryManager
- adds ItemReference object - contains (guid, quantity) these items serialized in memory as such
- adds CurrencyManager
- uses InventoryManagerMem naming for the `memory` InventoryManager to remove ambiguity from the `engine` one

Currency Manager actually has a 'list of currencies' but there is only one currency (money) so we just read that one instead of iterating over a range(1)