### PR TITLE
Added SeqCommentary and GUI window for log

### DIFF
--- a/GUI/__init__.py
+++ b/GUI/__init__.py
@@ -1,9 +1,11 @@
 from GUI.GUI import LayoutHelper, Window
 from GUI.menu import Menu, MenuManager
+from GUI.tools.commentary import AUTHORS
 
 __all__ = [
     "LayoutHelper",
     "MenuManager",
     "Menu",
     "Window",
+    "AUTHORS",
 ]

--- a/GUI/tools/commentary.py
+++ b/GUI/tools/commentary.py
@@ -1,0 +1,80 @@
+"""Menu window showing a scrolling log."""
+
+import logging
+import time
+from typing import Self
+
+from imgui_bundle import imgui
+
+from GUI.GUI import Window
+from GUI.menu import Menu
+
+logger = logging.getLogger(__name__)
+
+
+class CommentaryAuthor:
+    """Author of a commentary entry."""
+
+    def __init__(self: Self, name: str, color: imgui.ImVec4) -> None:
+        """Initialize a CommentaryAuthor object."""
+        self.name = name
+        self.color = color
+
+
+class AUTHORS:
+    """Static namespace of CommentaryAuthors."""
+
+    orkaboy = CommentaryAuthor(name="orkaboy", color=imgui.ImVec4(0.7, 0.1, 0.5, 1.0))
+
+
+class CommentaryEntry:
+    """Internal representation of a comment in the commentary log."""
+
+    def __init__(self: Self, author: CommentaryAuthor, text: str, lifetime: float) -> None:
+        """Initialize a CommentaryEntry object."""
+        self.author = author
+        self.text = text
+        self.timer = 0.0
+        self.lifetime = lifetime
+
+
+class CommentaryLog(Menu):
+    """Menu window showing a scrolling log."""
+
+    def __init__(self: Self, window: Window) -> None:
+        """Initialize a CommentaryLog object."""
+        super().__init__(window, title="Commentary Log")
+        self.timestamp = time.time()
+
+    def execute(self: Self, top_level: bool) -> bool:
+        self.window.start_window(self.title)
+
+        now = time.time()
+        delta = now - self.timestamp
+        self.timestamp = now
+
+        log = get_commentary_log()
+
+        for entry in log:
+            entry.timer += delta
+            imgui.text_colored(entry.author.color, entry.author.name)
+            imgui.same_line()
+            imgui.text_wrapped(f": {entry.text}")
+
+        imgui.set_scroll_y(imgui.get_scroll_max_y())
+
+        log[:] = [entry for entry in log if entry.timer < entry.lifetime]
+
+        ret = False
+        if not top_level and imgui.button("Back"):
+            ret = True
+        self.window.end_window()
+        return ret
+
+
+_commentary_log: list[CommentaryEntry] = []
+
+
+def get_commentary_log() -> list[CommentaryEntry]:
+    """Return a handle to the log."""
+    return _commentary_log

--- a/GUI/tools/commentary.py
+++ b/GUI/tools/commentary.py
@@ -1,6 +1,7 @@
 """Menu window showing a scrolling log."""
 
 import logging
+import random as rnd
 import time
 from typing import Self
 
@@ -24,7 +25,12 @@ class CommentaryAuthor:
 class AUTHORS:
     """Static namespace of CommentaryAuthors."""
 
+    tas = CommentaryAuthor(
+        name="TAS", color=imgui.ImVec4(rnd.random(), rnd.uniform(0.4, 1), rnd.random(), 1.0)
+    )
     orkaboy = CommentaryAuthor(name="orkaboy", color=imgui.ImVec4(0.7, 0.1, 0.5, 1.0))
+    eein = CommentaryAuthor(name="Eein", color=imgui.ImVec4(1.0, 1.0, 0.0, 1.0))
+    shenef = CommentaryAuthor(name="shenef", color=imgui.ImVec4(0.5, 0.0, 1.0, 1.0))
 
 
 class CommentaryEntry:
@@ -59,7 +65,7 @@ class CommentaryLog(Menu):
             entry.timer += delta
             imgui.text_colored(entry.author.color, entry.author.name)
             imgui.same_line()
-            imgui.text_wrapped(f": {entry.text}")
+            imgui.text_wrapped(entry.text)
 
         imgui.set_scroll_y(imgui.get_scroll_max_y())
 

--- a/engine/seq/__init__.py
+++ b/engine/seq/__init__.py
@@ -12,7 +12,7 @@ from engine.seq.interact import (
     SeqSkipUntilIdle,
     SeqTapDown,
 )
-from engine.seq.log import SeqDebug, SeqLog, SeqTextCrawl
+from engine.seq.log import SeqCommentary, SeqDebug, SeqLog, SeqTextCrawl
 from engine.seq.move import (
     CancelMove,
     Graplou,
@@ -47,6 +47,7 @@ __all__ = [
     "SeqDebug",
     "SeqLog",
     "SeqTextCrawl",
+    "SeqCommentary",
     "SeqBase",
     "SeqList",
     "SeqIf",

--- a/engine/seq/log.py
+++ b/engine/seq/log.py
@@ -6,6 +6,7 @@ from typing import Self
 
 from control import sos_ctrl
 from engine.seq.base import SeqBase
+from GUI.tools.commentary import CommentaryAuthor, CommentaryEntry, get_commentary_log
 
 logger = logging.getLogger(__name__)
 
@@ -82,3 +83,18 @@ class SeqTextCrawl(SeqBase):
             return ""
         cur_text, _ = self.text_nodes[self.step]
         return f"\n{cur_text}\n"
+
+
+class SeqCommentary(SeqBase):
+    """Prints text entries to a side window that looks like a chat."""
+
+    def __init__(self: Self, author: CommentaryAuthor, text: str, lifetime: float = 60.0) -> None:
+        """Initialize a SeqCommentary node."""
+        super().__init__()
+        self.entry = CommentaryEntry(author, text, lifetime)
+
+    def execute(self: Self, delta: float) -> bool:
+        log = get_commentary_log()
+        # Push data to commentary buffer
+        log.append(self.entry)
+        return True

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ import config
 from GUI import Menu, MenuManager, Window
 from GUI.battle_menu import BattleMenu
 from GUI.debug_menu import DebugMenu
+from GUI.tools.commentary import CommentaryLog
 from GUI.tools.nav_helper import NavHelper
 from GUI.tools.route_helper import RouteHelper
 from log_init import initialize_logging
@@ -43,6 +44,7 @@ if __name__ == "__main__":
             NavHelper(window=gui),
             RouteHelper(window=gui),
             BattleMenu(window=gui),
+            CommentaryLog(window=gui),
         ],
     )
     menu_manager.run()

--- a/route/start.py
+++ b/route/start.py
@@ -7,6 +7,7 @@ from control import sos_ctrl
 from engine.blackboard import blackboard, clear_blackboard
 from engine.seq import (
     SeqBase,
+    SeqCommentary,
     SeqDebug,
     SeqDelay,
     SeqIf,
@@ -14,6 +15,7 @@ from engine.seq import (
     SeqList,
     SeqLog,
 )
+from GUI import AUTHORS
 from log_init import reset_logging_time_reference
 from memory import (
     TitleCursorPosition,
@@ -132,6 +134,14 @@ class SoSStartGame(SeqList):
                 # ! The SoS window will not recognize input unless it is in focus!
                 SeqDelay(name="MANUAL: Focus SoS window!", timeout_in_s=2.5),
                 SeqDebug(name="SYSTEM", text="Press start to activate main menu."),
+                SeqCommentary(
+                    author=AUTHORS.tas,
+                    text="https://github.com/shenef/SoS-TAS\n"
+                    + "Thanks to everyone that contributed to the project:",
+                ),
+                SeqCommentary(author=AUTHORS.orkaboy, text="https://github.com/orkaboy"),
+                SeqCommentary(author=AUTHORS.eein, text="https://github.com/Eein"),
+                SeqCommentary(author=AUTHORS.shenef, text="https://github.com/shenef"),
                 SeqMenuStartButton(),
                 SeqDelay(name="Menu", timeout_in_s=1.5),
                 SeqIfNewGame(


### PR DESCRIPTION
Here's a fun little one. It adds functionality to inject a chat-log style flow (there's a GUI window that displays it) so we can add some dev commentary or something. The node itself is injected into the TAS sequence, but takes no time to execute, and after that the text is handled by the GUI window separately.

Each entry has a lifetime so we can clear them up after they are no longer relevant.

I set up a AUTHORS block where we can inject colored names for who is writing stuff.

Example usage:
![bild](https://github.com/shenef/SoS-TAS/assets/1805679/3b73d622-7886-4b17-ad5e-e4c5cd4508d4)

