### PR TITLE
fixes moonerang and randomly resetting consideration

### DIFF
--- a/engine/combat/appraisals/valere/moonerang.py
+++ b/engine/combat/appraisals/valere/moonerang.py
@@ -51,10 +51,9 @@ class Moonerang(SoSAppraisal):
                 return
 
         if (
-            # if we jump back after a failure
-            # combat_manager.read_back_to_slot() is True
-            # or if we kill the boss/enemy
+            # if you can select a character again
             combat_manager.selected_character is not PlayerPartyCharacter.NONE
+            # if we kill the boss/enemy
             or combat_manager.encounter_done is True
         ):
             self.step = SoSAppraisalStep.ActionComplete

--- a/engine/combat/appraisals/valere/moonerang.py
+++ b/engine/combat/appraisals/valere/moonerang.py
@@ -11,6 +11,7 @@ from engine.combat.utility.sos_appraisal import (
     SoSTimingType,
 )
 from memory.combat_manager import CombatDamageType, combat_manager_handle
+from memory.mappers.player_party_character import PlayerPartyCharacter
 
 logger = logging.getLogger(__name__)
 combat_manager = combat_manager_handle()
@@ -51,8 +52,9 @@ class Moonerang(SoSAppraisal):
 
         if (
             # if we jump back after a failure
-            combat_manager.read_back_to_slot() is True
+            # combat_manager.read_back_to_slot() is True
             # or if we kill the boss/enemy
+            combat_manager.selected_character is not PlayerPartyCharacter.NONE
             or combat_manager.encounter_done is True
         ):
             self.step = SoSAppraisalStep.ActionComplete

--- a/engine/combat/appraisals/valere/moonerang.py
+++ b/engine/combat/appraisals/valere/moonerang.py
@@ -19,6 +19,7 @@ combat_manager = combat_manager_handle()
 
 class Moonerang(SoSAppraisal):
     HIT_AT_POSITION_VALUE = 0.82
+    MAX_HITS = 100
 
     def __init__(
         self: Self,
@@ -52,7 +53,8 @@ class Moonerang(SoSAppraisal):
 
         if (
             # if you can select a character again
-            combat_manager.selected_character is not PlayerPartyCharacter.NONE
+            combat_manager.read_projectile_hit_count() >= self.MAX_HITS
+            or combat_manager.selected_character is not PlayerPartyCharacter.NONE
             # if we kill the boss/enemy
             or combat_manager.encounter_done is True
         ):

--- a/engine/combat/combat_controller.py
+++ b/engine/combat/combat_controller.py
@@ -116,7 +116,7 @@ class CombatController:
         if self.controller.execute_consideration():
             return False
 
-        if self.controller.action.appraisal.execute():
+        if self.controller.execute_appraisal():
             return False
 
         return False

--- a/engine/combat/controllers/encounter_controller.py
+++ b/engine/combat/controllers/encounter_controller.py
@@ -108,6 +108,9 @@ class EncounterController:
         If the consideration doesn't believe the situation is valid, execute changing the selected
         consideration (character). This will rotate the cursor to the next available consideration
         until it finds the one it expects.
+
+        If the appraisal step is not the initial step, we should not be executing the consideration
+        to prevent it from moving the cursor when we are in an actions lifecycle.
         """
         if self.action.appraisal.step != SoSAppraisalStep.SelectingCommand:
             return False

--- a/engine/combat/controllers/encounter_controller.py
+++ b/engine/combat/controllers/encounter_controller.py
@@ -4,6 +4,7 @@ from typing import Self
 from control import sos_ctrl
 from engine.combat.contexts.reasoner_execution_context import ReasonerExecutionContext
 from engine.combat.utility.core.action import Action
+from engine.combat.utility.sos_appraisal import SoSAppraisalStep
 from engine.combat.utility.sos_consideration import SoSConsideration
 from engine.combat.utility.sos_reasoner import SoSReasoner
 from memory import (
@@ -108,6 +109,9 @@ class EncounterController:
         consideration (character). This will rotate the cursor to the next available consideration
         until it finds the one it expects.
         """
+        if self.action.appraisal.step != SoSAppraisalStep.SelectingCommand:
+            return False
+
         if not self._consideration_valid():
             # logger.warning("Consideration is not valid, move cursor")
             consideration: SoSConsideration = self.action.consideration

--- a/memory/combat_manager.py
+++ b/memory/combat_manager.py
@@ -167,7 +167,7 @@ class CombatManager:
                     self.projectile_hit_count = self.read_projectile_hit_count()
                     self.projectile_speed = self.read_projectile_speed()
 
-        except Exception:
+        except Exception as e:  # noqa: F841
             # logger.debug(f"Combat Manager Reloading - {type(e)}")
             self.__init__()
 

--- a/memory/combat_manager.py
+++ b/memory/combat_manager.py
@@ -167,7 +167,7 @@ class CombatManager:
                     self.projectile_hit_count = self.read_projectile_hit_count()
                     self.projectile_speed = self.read_projectile_speed()
 
-        except Exception as e:  # noqa: F841
+        except Exception:
             # logger.debug(f"Combat Manager Reloading - {type(e)}")
             self.__init__()
 
@@ -284,18 +284,19 @@ class CombatManager:
 
         selected_attack_target_guid = ""
         selected_skill_target_guid = ""
-        first_player_ptr = self.memory.follow_pointer(
-            self.base,
-            [
-                self.current_encounter_base,
-                0x120,
-                0x98,
-                0x40,
-                0x10,
-                0x20,
-                0x0,
-            ],
-        )
+        with contextlib.suppress(Exception):
+            first_player_ptr = self.memory.follow_pointer(
+                self.base,
+                [
+                    self.current_encounter_base,
+                    0x120,
+                    0x98,
+                    0x40,
+                    0x10,
+                    0x20,
+                    0x0,
+                ],
+            )
         with contextlib.suppress(Exception):
             target_unique_id_base = self.memory.follow_pointer(
                 first_player_ptr,


### PR DESCRIPTION
- this seems to fix the moonerang issues we were having. 
- fixes an exception during battle start sequence that causes combat manager to reload

 
can drop the commented read_back_to_slot after testing if it works (also remove it from combat manager.