### PR TITLE
Combat move recovery

### DIFF
--- a/engine/combat/combat_and_move.py
+++ b/engine/combat/combat_and_move.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Callable
 from enum import Enum, auto
 from typing import Any, Self
@@ -16,6 +17,7 @@ from engine.seq import (
 )
 from memory import combat_manager_handle, level_up_manager_handle
 
+logger = logging.getLogger(__name__)
 combat_manager = combat_manager_handle()
 level_up_manager = level_up_manager_handle()
 
@@ -129,12 +131,15 @@ class SeqCombatAndMove(SeqMove):
                     ctrl.set_neutral()
                     ctrl.toggle_confirm(False)
                     if self.recovery_path is not None:
+                        logger.info("Finished combat, executing recovery path")
                         self.state = SeqCombatAndMove.FSM.RECOVER
                     else:
+                        logger.info("Finished combat, continuing navigation")
                         self.state = SeqCombatAndMove.FSM.MOVE
             case SeqCombatAndMove.FSM.RECOVER:
                 # After combat, run the recovery node, then continue regular movement
                 if self.recovery_path.execute(delta):
+                    logger.info("Finished recovery path, continuing navigation")
                     self.state = SeqCombatAndMove.FSM.MOVE
 
     def __repr__(self: Self) -> str:

--- a/route/evermist_island/mountain_trail.py
+++ b/route/evermist_island/mountain_trail.py
@@ -385,14 +385,22 @@ class MountainTrail(SeqList):
                         Vec3(66.825, 73.002, 137.150),
                         Vec3(68.642, 73.002, 134.562),
                         InteractMove(83.560, 73.002, 134.500),
+                        # Base of cliff
                         Vec3(87.935, 73.002, 138.962),
+                        # A point up the cliff, slightly into it to force move up
+                        InteractMove(87.986, 80.950, 139.600),
                     ],
+                    recovery_path=SeqMove(
+                        name="Return to base of hill",
+                        coords=[
+                            Vec3(88.037, 73.002, 139.546),
+                        ],
+                    ),
                 ),
                 SeqClimb(
                     name="Climb cliff",
                     coords=[
                         # TODO(orkaboy): There's a risk of being caught by the enemy here
-                        InteractMove(87.935, 77.453, 139.530),
                         Vec3(88.451, 83.540, 139.530),
                         Vec3(89.655, 83.986, 139.990),
                         Vec3(88.993, 89.002, 140.653),

--- a/route/evermist_island/mountain_trail.py
+++ b/route/evermist_island/mountain_trail.py
@@ -323,7 +323,7 @@ class MountainTrail(SeqList):
                         Vec3(173.540, 24.002, 136.120),
                     ],
                 ),
-                SeqCombatAndMove(
+                SeqMove(
                     name="Navigate trail",
                     coords=[
                         Vec3(178.474, 24.002, 132.236),
@@ -331,6 +331,11 @@ class MountainTrail(SeqList):
                         Vec3(186.408, 24.002, 127.659),
                         Vec3(188.581, 24.002, 124.294),
                         HoldDirection(105.206, 49.002, 123.163, joy_dir=Vec2(1, -1)),
+                    ],
+                ),
+                SeqCombatAndMove(
+                    name="Navigate trail",
+                    coords=[
                         Vec3(105.206, 49.002, 119.837),
                         Vec3(86.618, 49.002, 116.410),
                         InteractMove(79.059, 45.002, 116.298),


### PR DESCRIPTION
Fallback for the bug with the Ram in the mountain trail area.

Adds a piece of code that will execute a any node after any combat during `SeqCombatAndMove`. This can be used to reposition TAS after combat has moved it away from its original path.