### PR TITLE
Added ability to delay a commentary entry

### DIFF
--- a/GUI/tools/commentary.py
+++ b/GUI/tools/commentary.py
@@ -36,11 +36,14 @@ class AUTHORS:
 class CommentaryEntry:
     """Internal representation of a comment in the commentary log."""
 
-    def __init__(self: Self, author: CommentaryAuthor, text: str, lifetime: float) -> None:
+    def __init__(
+        self: Self, author: CommentaryAuthor, text: str, lifetime: float, delay: float
+    ) -> None:
         """Initialize a CommentaryEntry object."""
         self.author = author
         self.text = text
         self.timer = 0.0
+        self.delay = delay
         self.lifetime = lifetime
 
 
@@ -68,9 +71,10 @@ class CommentaryLog(Menu):
 
         for entry in log:
             entry.timer += delta
-            imgui.text_colored(entry.author.color, entry.author.name)
-            imgui.same_line()
-            imgui.text_wrapped(entry.text)
+            if entry.timer >= entry.delay:
+                imgui.text_colored(entry.author.color, entry.author.name)
+                imgui.same_line()
+                imgui.text_wrapped(entry.text)
 
         imgui.set_scroll_y(imgui.get_scroll_max_y())
 

--- a/engine/seq/log.py
+++ b/engine/seq/log.py
@@ -88,10 +88,17 @@ class SeqTextCrawl(SeqBase):
 class SeqCommentary(SeqBase):
     """Prints text entries to a side window that looks like a chat."""
 
-    def __init__(self: Self, author: CommentaryAuthor, text: str, lifetime: float = 60.0) -> None:
+    def __init__(
+        self: Self, author: CommentaryAuthor, text: str, delay: float = 0.0, lifetime: float = 60.0
+    ) -> None:
         """Initialize a SeqCommentary node."""
         super().__init__()
-        self.entry = CommentaryEntry(author, text, lifetime)
+        self.entry = CommentaryEntry(
+            author=author,
+            text=text,
+            delay=delay,
+            lifetime=lifetime,
+        )
 
     def execute(self: Self, delta: float) -> bool:
         log = get_commentary_log()


### PR DESCRIPTION
Should be able to create more of a back-and-forth commentary flow. Even if multiple commentary entries are added at the same point, this allows some of them to show up later in the log with a delay. Lifetime is still in relation to when the entry is spawned, not to when the entry shows up in the log.