### PR TITLE
adds dweller of woe fight

### DIFF
--- a/engine/combat/combat_controller.py
+++ b/engine/combat/combat_controller.py
@@ -4,6 +4,7 @@ from typing import Self
 
 from control import sos_ctrl
 from engine.combat.controllers import (
+    DwellerOfWoeEncounterController,
     ElderMistEncounterController,
     EncounterController,
     FirstEncounterController,
@@ -30,6 +31,10 @@ class CombatController:
     # TODO(eein): Use objects/mappers for these later on.
     ELDER_MIST_ENEMY_GUID = "962aa552d33fc124782b230fce9185ce"
     ELDER_MIST_TRIAL_LEVEL_GUID = "11810c4630980eb43abf7fecebfd5a6b"
+    DWELLER_OF_WOE_GUID_LIST = [
+        "bcde1eb0ea076f846a0ee20287d88204",  # true dweller
+        "807fd9a36ea523f4aa7d532ddc565a69",  # dweller
+    ]
 
     class FSM(Enum):
         """Finite-state machine States."""
@@ -130,11 +135,16 @@ class CombatController:
             case CombatEncounter.LiveManaTutorial:
                 return LiveManaTutorialController()
             case _:
-                match map(lambda x: x.guid, combat_manager.enemies):
+                match list(map(lambda x: x.guid, combat_manager.enemies)):
                     # Handle Enemy Specific Controllers
                     # Elder Mist Fight
                     case _ as enemies if self.ELDER_MIST_ENEMY_GUID in enemies:
                         return ElderMistEncounterController()
+                    # Dweller of Woe fight
+                    case _ as enemies if any(
+                        True for x in enemies if x in self.DWELLER_OF_WOE_GUID_LIST
+                    ):
+                        return DwellerOfWoeEncounterController()
                     # Handle level specific controllers or fall back to
                     # standard encounter controller
                     case _:

--- a/engine/combat/controllers/__init__.py
+++ b/engine/combat/controllers/__init__.py
@@ -1,3 +1,6 @@
+from engine.combat.controllers.dweller_of_woe_encounter_controller import (
+    DwellerOfWoeEncounterController,
+)
 from engine.combat.controllers.elder_mist_controller import (
     ElderMistEncounterController,
 )
@@ -18,4 +21,5 @@ __all__ = [
     "SecondEncounterController",
     "LiveManaTutorialController",
     "ElderMistEncounterController",
+    "DwellerOfWoeEncounterController",
 ]

--- a/engine/combat/controllers/dweller_of_woe_encounter_controller.py
+++ b/engine/combat/controllers/dweller_of_woe_encounter_controller.py
@@ -1,0 +1,32 @@
+import logging
+from typing import Self
+
+from engine.combat.contexts.reasoner_execution_context import ReasonerExecutionContext
+from engine.combat.controllers.encounter_controller import EncounterController
+from engine.combat.utility.sos_reasoner import SoSReasoner
+from memory import (
+    combat_manager_handle,
+)
+
+logger = logging.getLogger(__name__)
+combat_manager = combat_manager_handle()
+
+
+class DwellerOfWoeEncounterController(EncounterController):
+    """
+    Handles the elder mist fight.
+
+    The general basis of the fight is the sword must be prioritized first,
+    then the boss can be attacked.
+    """
+
+    DWELLER_OF_WOE = "807fd9a36ea523f4aa7d532ddc565a69"
+    DWELLER_OF_WOE_CLONE = "e1685476dd793e44c9c8909fe0b3622f"
+    TRUE_DWELLER_OF_WOE = "bcde1eb0ea076f846a0ee20287d88204"
+
+    def __init__(self: Self) -> None:
+        """Initialize a new DwellerOfWoeEncounterController object."""
+        super().__init__()
+        priority_list = [self.TRUE_DWELLER_OF_WOE, self.DWELLER_OF_WOE, self.DWELLER_OF_WOE_CLONE]
+        reasoner_execution_context = ReasonerExecutionContext(priority_list)
+        self.reasoner = SoSReasoner(reasoner_execution_context)

--- a/engine/combat/utility/sos_consideration.py
+++ b/engine/combat/utility/sos_consideration.py
@@ -49,6 +49,14 @@ class SoSConsideration(Consideration):
     def _default_appraisals(self: Self) -> list[SoSAppraisal]:
         """Generate default appraisals generic to every consideration."""
         attacks: list[BasicAttack] = []
+        if self.actor.character is PlayerPartyCharacter.Moraine:
+            moraine_rune = BasicAttack(
+                caster=self.actor.character,
+                boost=0,
+            )
+            attacks.append(moraine_rune)
+            return attacks
+
         for boost in range(0, 4):  # Generate [0,1,2,3]
             basic_attack = BasicAttack(
                 caster=self.actor.character,

--- a/memory/mappers/player_party_character.py
+++ b/memory/mappers/player_party_character.py
@@ -12,9 +12,11 @@ class PlayerPartyCharacter(Enum):
     Serai = "Seraï"
     Reshan = "Resh'an"
     Bst = "B'st"
+    Moraine = "Moraine"
 
     def parse_definition_id(definition_id: str) -> Self:
         ascii_data = definition_id.encode("ascii", "ignore")
+
         if ascii_data == b"Z\x00A\x00L\x00E\x00":
             return PlayerPartyCharacter.Zale
         if ascii_data == b"V\x00A\x00L\x00E\x00":
@@ -27,4 +29,6 @@ class PlayerPartyCharacter(Enum):
             return PlayerPartyCharacter.Reshan
         if ascii_data == b"B\x00S\x00T\x00\x00\x00":
             return PlayerPartyCharacter.Bst
+        if ascii_data == b"M\x00A\x00S\x00T\x00":
+            return PlayerPartyCharacter.Moraine
         return PlayerPartyCharacter.NONE


### PR DESCRIPTION
- makes moraines 'attack' not boost (basically hold rune on priority target)
- adds a priority target controller so we're not trying to attack untargetable characters - this handles both stages of the fight
- also has the list fix, may run into a merge conflict later.
- currently moonerang cannot be used because it still considers brugaves and erlina as an 'enemy' when counting