### PR TITLE
Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Logs
 
 # Ruff output
 report.json
+
+# virtual env
+venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ fail_fast: false
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.1.13'
+    rev: 'v0.3.7'
     hooks:
       - id: ruff-format
       - id: ruff

--- a/GUI/GUI.py
+++ b/GUI/GUI.py
@@ -222,6 +222,7 @@ class LayoutHelper:
         ----
             ui_element: Check the demo window for valid values
             color: Tuple of (r, g, b, a) values.
+
         """
         ui_element = getattr(imgui.Col_, ui_element)
         imgui.get_style().set_color_(ui_element, color)

--- a/control/sos.py
+++ b/control/sos.py
@@ -1,6 +1,8 @@
 # Libraries and Core Files
 import logging
 import time
+import os
+
 from enum import IntEnum
 from typing import Self
 
@@ -31,13 +33,17 @@ class SoSController:
         self.ctrl = ctrl_handle()
         self.delay = delay  # In seconds
         self.dpad = self.DPad(ctrl=self.ctrl, delay=self.delay)
+        self.os_name = os.name
 
     # Wrappers
     def set_button(self: Self, x_key: Buttons, value: int | float) -> None:
         self.ctrl.set_button(x_key, value)
 
     def set_joystick(self: Self, direction: Vec2) -> None:
-        self.ctrl.set_joystick(direction.x, direction.y)
+        if self.os_name == "posix":
+           self.ctrl.set_joystick(direction.x, -direction.y)
+        else:
+           self.ctrl.set_joystick(direction.x, direction.y)
 
     def set_neutral(self: Self) -> None:
         self.ctrl.set_neutral()

--- a/control/sos.py
+++ b/control/sos.py
@@ -1,8 +1,7 @@
 # Libraries and Core Files
 import logging
-import time
 import os
-
+import time
 from enum import IntEnum
 from typing import Self
 
@@ -41,9 +40,9 @@ class SoSController:
 
     def set_joystick(self: Self, direction: Vec2) -> None:
         if self.os_name == "posix":
-           self.ctrl.set_joystick(direction.x, -direction.y)
+            self.ctrl.set_joystick(direction.x, -direction.y)
         else:
-           self.ctrl.set_joystick(direction.x, direction.y)
+            self.ctrl.set_joystick(direction.x, direction.y)
 
     def set_neutral(self: Self) -> None:
         self.ctrl.set_neutral()

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
-pre-commit >= 3.5.0
-ruff >= 0.1.1
+pre-commit >= 3.7.0
+ruff >= 0.3.7

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1713248628,
+        "narHash": "sha256-NLznXB5AOnniUtZsyy/aPWOk8ussTuePp2acb9U+ISA=",
+        "rev": "5672bc9dbf9d88246ddab5ac454e82318d094bb8",
+        "revCount": 612413,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.612413%2Brev-5672bc9dbf9d88246ddab5ac454e82318d094bb8/018ee842-f990-7838-843a-63e9d591101c/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1.%2A.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
             pkgs.libGL.dev
             pkgs.stdenv.cc.cc.lib
             pkgs.libevdev
+            pkgs.xorg.libXtst
           ];
           postShellHook = ''
             export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${pkgs.lib.makeLibraryPath[
@@ -28,6 +29,7 @@
               pkgs.libGL.dev
               pkgs.stdenv.cc.cc.lib
               pkgs.libevdev
+              pkgs.xorg.libXtst
             ]};
           '';
           packages = with pkgs; [ 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,43 @@
+{
+  description = "A Nix-flake-based Python development environment";
+
+  inputs.nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.*.tar.gz";
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forEachSupportedSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f {
+        pkgs = import nixpkgs { inherit system; };
+      });
+    in
+    {
+      devShells = forEachSupportedSystem ({ pkgs }: {
+        default = pkgs.mkShell {
+          venvDir = "venv";
+          buildInputs = [
+            pkgs.glfw
+            pkgs.libGL
+            pkgs.libGL.dev
+            pkgs.stdenv.cc.cc.lib
+            pkgs.libevdev
+          ];
+          postShellHook = ''
+            export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${pkgs.lib.makeLibraryPath[
+              pkgs.glfw
+              pkgs.libGL
+              pkgs.libGL.dev
+              pkgs.stdenv.cc.cc.lib
+              pkgs.libevdev
+            ]};
+          '';
+          packages = with pkgs; [ 
+            python312 
+          ] ++
+            (with pkgs.python312Packages; [ 
+              pip
+              venvShellHook 
+            ]);
+        };
+      });
+    };
+}

--- a/memory/combat_manager.py
+++ b/memory/combat_manager.py
@@ -134,7 +134,8 @@ class CombatManager:
         self.projectile_speed = 0.0
 
     def update(self: Self) -> None:
-        try:
+
+        # try:
             if self.memory.ready_for_updates:
                 if self.base is None or self.fields_base is None:
                     self.encounter_done = True
@@ -151,9 +152,9 @@ class CombatManager:
                 else:
                     self._read_encounter_done()
 
-                    if self.encounter_done is True:
-                        self.combat_controller = CombatEncounter.Basic
-                        return
+                    # if self.encounter_done is True:
+                    #     self.combat_controller = CombatEncounter.Basic
+                    #     return
 
                     self._read_combat_controller()
                     self._read_combo_and_ultimates()
@@ -167,9 +168,9 @@ class CombatManager:
                     self.projectile_hit_count = self.read_projectile_hit_count()
                     self.projectile_speed = self.read_projectile_speed()
 
-        except Exception as _e:
-            # logger.debug(f"Combat Manager Reloading - {type(_e)}")
-            self.__init__()
+        # except Exception as _e:
+        #     # logger.debug(f"Combat Manager Reloading - {type(_e)}")
+        #     self.__init__()
 
     def _read_combo_and_ultimates(self: Self) -> None:
         if self._should_update():
@@ -774,7 +775,7 @@ class CombatManager:
                     #    - 0x20 - Item[0] -> Pointer 0xF30d0930
                     #    - 0x20 - Item[0] -> Pointer 0x00000000
                     #    - 0x20 - Item[0] -> Pointer 0xF30d0930
-                    if hex(item) == "0x0":
+                    if hex(item) == "0x0" or hex(item) == "0":
                         address += self.ITEM_OBJECT_OFFSET
                         continue
 
@@ -793,7 +794,9 @@ class CombatManager:
                     magic_attack = self.memory.read_int(enemy_data + 0x30)
                     magic_defense = self.memory.read_int(enemy_data + 0x34)
                     enemy_guid = self.memory.read_guid(guid + 0x14)
+                    print(enemy_guid)
                     enemy_unique_id = self.memory.read_uuid(unique_id + 0x14)
+                    print(enemy_unique_id)
                     turns_to_action = self.memory.read_short(casting_data + 0x24)
                     total_spell_locks = self.memory.read_short(casting_data + 0x28)
 

--- a/memory/combat_manager.py
+++ b/memory/combat_manager.py
@@ -134,43 +134,42 @@ class CombatManager:
         self.projectile_speed = 0.0
 
     def update(self: Self) -> None:
-
         # try:
-            if self.memory.ready_for_updates:
-                if self.base is None or self.fields_base is None:
-                    self.encounter_done = True
-                    singleton_ptr = self.memory.get_singleton_by_class_name("CombatManager")
+        if self.memory.ready_for_updates:
+            if self.base is None or self.fields_base is None:
+                self.encounter_done = True
+                singleton_ptr = self.memory.get_singleton_by_class_name("CombatManager")
 
-                    if singleton_ptr is None:
-                        return
-                    self.base = self.memory.get_class_base(singleton_ptr)
-                    self.fields_base = self.memory.get_class_fields_base(singleton_ptr)
-                    self.current_encounter_base = self.memory.get_field(
-                        self.fields_base, "currentEncounter"
-                    )
+                if singleton_ptr is None:
+                    return
+                self.base = self.memory.get_class_base(singleton_ptr)
+                self.fields_base = self.memory.get_class_fields_base(singleton_ptr)
+                self.current_encounter_base = self.memory.get_field(
+                    self.fields_base, "currentEncounter"
+                )
 
-                else:
-                    self._read_encounter_done()
+            else:
+                self._read_encounter_done()
 
-                    # if self.encounter_done is True:
-                    #     self.combat_controller = CombatEncounter.Basic
-                    #     return
+                # if self.encounter_done is True:
+                #     self.combat_controller = CombatEncounter.Basic
+                #     return
 
-                    self._read_combat_controller()
-                    self._read_combo_and_ultimates()
-                    self._read_players()
-                    self._read_enemies()
-                    self._read_battle_commands()
-                    if not self.battle_command_has_focus:
-                        self._read_skill_commands()
-                    self._read_live_mana()
-                    self._read_current_target()
-                    self.projectile_hit_count = self.read_projectile_hit_count()
-                    self.projectile_speed = self.read_projectile_speed()
+                self._read_combat_controller()
+                self._read_combo_and_ultimates()
+                self._read_players()
+                self._read_enemies()
+                self._read_battle_commands()
+                if not self.battle_command_has_focus:
+                    self._read_skill_commands()
+                self._read_live_mana()
+                self._read_current_target()
+                self.projectile_hit_count = self.read_projectile_hit_count()
+                self.projectile_speed = self.read_projectile_speed()
 
-        # except Exception as _e:
-        #     # logger.debug(f"Combat Manager Reloading - {type(_e)}")
-        #     self.__init__()
+    # except Exception as _e:
+    #     # logger.debug(f"Combat Manager Reloading - {type(_e)}")
+    #     self.__init__()
 
     def _read_combo_and_ultimates(self: Self) -> None:
         if self._should_update():

--- a/memory/combat_manager.py
+++ b/memory/combat_manager.py
@@ -151,9 +151,9 @@ class CombatManager:
             else:
                 self._read_encounter_done()
 
-                # if self.encounter_done is True:
-                #     self.combat_controller = CombatEncounter.Basic
-                #     return
+                if self.encounter_done is True:
+                    self.combat_controller = CombatEncounter.Basic
+                    return
 
                 self._read_combat_controller()
                 self._read_combo_and_ultimates()
@@ -178,7 +178,7 @@ class CombatManager:
                     self.base,
                     [
                         self.current_encounter_base,
-                        0x120,
+                        0x128,
                         0x98,
                         0x50,
                         0x0,
@@ -208,7 +208,7 @@ class CombatManager:
                     self.base,
                     [
                         self.current_encounter_base,
-                        0x120,
+                        0x128,
                         0x58,
                         0x10,
                         0x20,
@@ -220,7 +220,7 @@ class CombatManager:
                     self.base,
                     [
                         self.current_encounter_base,
-                        0x120,
+                        0x128,
                         0x58,
                         0x10,
                         0x20,
@@ -292,7 +292,7 @@ class CombatManager:
                 self.base,
                 [
                     self.current_encounter_base,
-                    0x120,
+                    0x128,
                     0x98,
                     0x40,
                     0x10,
@@ -324,7 +324,7 @@ class CombatManager:
                     0x30,
                     0xA8,
                     0x80,
-                    0x40,
+                    0x48,
                     0x100,
                     0x80,
                     0xF8,
@@ -356,7 +356,7 @@ class CombatManager:
                     0x20,
                     0xA8,
                     0x80,
-                    0x40,
+                    0x48,
                     0x100,
                     0x80,
                     0xF8,
@@ -383,7 +383,7 @@ class CombatManager:
             try:
                 combat_controller_ptr = self.memory.follow_pointer(
                     self.base,
-                    [self.current_encounter_base, 0x120, 0x0, 0x78, 0x10, 0x0],
+                    [self.current_encounter_base, 0x128, 0x0, 0x78, 0x10, 0x0],
                 )
 
                 controller = self.memory.read_string(combat_controller_ptr + 0x0, 25)
@@ -497,7 +497,7 @@ class CombatManager:
     def _read_battle_commands(self: Self) -> None:
         if self._should_update():
             battle_command_selector = self.memory.follow_pointer(
-                self.base, [self.current_encounter_base, 0x138, 0x50, 0x68, 0x0]
+                self.base, [self.current_encounter_base, 0x140, 0x50, 0x68, 0x0]
             )
             # Checks if we lost access to the selector pointer for a brief period as the UI changes.
             if battle_command_selector == self.NULL_POINTER:
@@ -534,7 +534,7 @@ class CombatManager:
     def _read_skill_commands(self: Self) -> None:
         if self._should_update():
             skill_command_selector = self.memory.follow_pointer(
-                self.base, [self.current_encounter_base, 0x138, 0x50, 0x78, 0x0]
+                self.base, [self.current_encounter_base, 0x140, 0x50, 0x78, 0x0]
             )
             # Checks if we lost access to the selector pointer for a brief period as the UI changes.
             if skill_command_selector == self.NULL_POINTER:
@@ -577,7 +577,7 @@ class CombatManager:
                     self.base, [self.current_encounter_base, 0x0]
                 )
                 if current_encounter:
-                    done = self.memory.read_bool(current_encounter + 0x162)
+                    done = self.memory.read_bool(current_encounter + 0x16A)
                     self.encounter_done = done
                     return
             except Exception:
@@ -596,14 +596,14 @@ class CombatManager:
     def _read_live_mana(self: Self) -> None:
         if self._should_update():
             small_live_mana = self.memory.follow_pointer(
-                self.base, [self.current_encounter_base, 0x78, 0x20, 0x0]
+                self.base, [self.current_encounter_base, 0x80, 0x20, 0x0]
             )
             if small_live_mana == self.NULL_POINTER:
                 self.small_live_mana = 0
                 self.big_live_mana = 0
                 return
             big_live_mana = self.memory.follow_pointer(
-                self.base, [self.current_encounter_base, 0x78, 0x28, 0x0]
+                self.base, [self.current_encounter_base, 0x80, 0x28, 0x0]
             )
             if big_live_mana == self.NULL_POINTER:
                 self.small_live_mana = 0
@@ -620,11 +620,11 @@ class CombatManager:
             selected_character = PlayerPartyCharacter.NONE
             try:
                 panel_count_ptr = self.memory.follow_pointer(
-                    self.base, [self.current_encounter_base, 0x120, 0x98, 0x0]
+                    self.base, [self.current_encounter_base, 0x128, 0x98, 0x0]
                 )
                 panel_count = self.memory.read_int(panel_count_ptr + 0x5C)
                 player_panels_list = self.memory.follow_pointer(
-                    self.base, [self.current_encounter_base, 0x120, 0x98, 0x40, 0x0]
+                    self.base, [self.current_encounter_base, 0x128, 0x98, 0x40, 0x0]
                 )
             except Exception:
                 self.players = []
@@ -747,7 +747,7 @@ class CombatManager:
     def _read_enemies(self: Self) -> None:
         if self._should_update():
             enemy_targets = self.memory.follow_pointer(
-                self.base, [self.current_encounter_base, 0x180, 0x0]
+                self.base, [self.current_encounter_base, 0x188, 0x0]
             )
             # item is a list of pointers of size 0x08
             items = self.memory.follow_pointer(
@@ -793,9 +793,7 @@ class CombatManager:
                     magic_attack = self.memory.read_int(enemy_data + 0x30)
                     magic_defense = self.memory.read_int(enemy_data + 0x34)
                     enemy_guid = self.memory.read_guid(guid + 0x14)
-                    print(enemy_guid)
                     enemy_unique_id = self.memory.read_uuid(unique_id + 0x14)
-                    print(enemy_unique_id)
                     turns_to_action = self.memory.read_short(casting_data + 0x24)
                     total_spell_locks = self.memory.read_short(casting_data + 0x28)
 

--- a/memory/combat_manager.py
+++ b/memory/combat_manager.py
@@ -383,10 +383,10 @@ class CombatManager:
             try:
                 combat_controller_ptr = self.memory.follow_pointer(
                     self.base,
-                    [self.current_encounter_base, 0x128, 0x0, 0x78, 0x10, 0x0],
+                    [self.current_encounter_base, 0x128, 0x0, 0x10, 0x0],
                 )
 
-                controller = self.memory.read_string(combat_controller_ptr + 0x0, 25)
+                controller = self.memory.read_raw_string(combat_controller_ptr, 25)
                 match controller:
                     case s if s.startswith("FirstEncounter"):
                         self.combat_controller = CombatEncounter.FirstEncounter

--- a/memory/core.py
+++ b/memory/core.py
@@ -126,8 +126,11 @@ class SoSMemory:
     def read_int(self: Self, ptr: int) -> int:
         return pyMeow.r_int(self.pm, ptr)
 
-    def read_short(self: Self, ptr: int) -> int:
-        return pyMeow.r_ints(self.pm, ptr)
+
+    def read_short(self: Self, address: int):
+        bytes = pyMeow.r_bytes(self.pm, address, struct.calcsize("h"))
+        bytes = struct.unpack("<h", bytes)[0]
+        return bytes
 
     # Reads the garbled uuid string utf-8 field provided by Sea Of Stars
     # For example, for "TitleScreen" you may see:
@@ -135,9 +138,11 @@ class SoSMemory:
     # b'T\x00i\x00t\x00t\x00l\x00e\x00S\x00c\x00r\x00e\x00e\x00n'
     # To "fix" this string, you will need to run value.replace("\x00", "")
     def read_uuid(self: Self, ptr: int) -> str:
-        string_bytes = pyMeow.r_bytes(self.pm, ptr, 71)
+        string = pyMeow.bytes_to_string(self.pm, ptr, 37 * 2)
+        print("UUID")
+        print(string)
 
-        return codecs.decode(string_bytes, "UTF-8")
+        return string
 
     # Reads the garbled guid string utf-8 field provided by Sea Of Stars
     # For example, for "TitleScreen" you may see:
@@ -145,14 +150,14 @@ class SoSMemory:
     # This returns as example: e6ac627711e4ee44da103c47d1cd5736
     # To "fix" this string, you will need to run value.replace("\x00", "")
     def read_guid(self: Self, ptr: int) -> str:
-        string_bytes = pyMeow.r_bytes(self.pm, ptr, 64)
-
-        return codecs.decode(string_bytes, "UTF-8")
+        string = pyMeow.bytes_to_string(self.pm, ptr, 64)
+        print("GUID")
+        print(string)
+        return string
 
     def read_string(self: Self, ptr: int, length: int) -> str:
-        string_bytes = pyMeow.r_bytes(self.pm, ptr, length)
-
-        return codecs.decode(string_bytes, "UTF-8")
+        string = pyMeow.bytes_to_string(self.pm, ptr, length)
+        return string
 
     # Scans the module/image class list for a specific class name by string.
     def get_class(self: Self, class_name: str) -> int | None:

--- a/memory/core.py
+++ b/memory/core.py
@@ -125,10 +125,9 @@ class SoSMemory:
     def read_int(self: Self, ptr: int) -> int:
         return pyMeow.r_int(self.pm, ptr)
 
-    def read_short(self: Self, address: int):
-        bytes = pyMeow.r_bytes(self.pm, address, struct.calcsize("h"))
-        bytes = struct.unpack("<h", bytes)[0]
-        return bytes
+    def read_short(self: Self, address: int) -> str:
+        returned_bytes = pyMeow.r_bytes(self.pm, address, struct.calcsize("h"))
+        return struct.unpack("<h", returned_bytes)[0]
 
     # Reads the garbled uuid string utf-8 field provided by Sea Of Stars
     # For example, for "TitleScreen" you may see:
@@ -218,15 +217,13 @@ class SoSMemory:
             address = aob_scan[0] - 4
             self.type_info_definition_table = address + 0x4 + pyMeow.r_int(self.pm, address)
 
-    def read_ulonglong(self: Self, address: int):
-        bytes = pyMeow.r_bytes(self.pm, address, struct.calcsize("Q"))
-        bytes = struct.unpack("<Q", bytes)[0]
-        return bytes
+    def read_ulonglong(self: Self, address: int) -> int:
+        returned_bytes = pyMeow.r_bytes(self.pm, address, struct.calcsize("Q"))
+        return struct.unpack("<Q", returned_bytes)[0]
 
-    def read_longlong(self: Self, address: int):
-        bytes = pyMeow.r_bytes(self.pm, address, struct.calcsize("q"))
-        bytes = struct.unpack("<q", bytes)[0]
-        return bytes
+    def read_longlong(self: Self, address: int) -> int:
+        returned_bytes = pyMeow.r_bytes(self.pm, address, struct.calcsize("q"))
+        return struct.unpack("<q", returned_bytes)[0]
 
     # Gets the Assembly-CSharp image where the games code lives so it can be used as a module base
     def get_image(self: Self, assembly_name: str = "Assembly-CSharp") -> int:

--- a/memory/core.py
+++ b/memory/core.py
@@ -129,24 +129,17 @@ class SoSMemory:
         returned_bytes = pyMeow.r_bytes(self.pm, address, struct.calcsize("h"))
         return struct.unpack("<h", returned_bytes)[0]
 
-    # Reads the garbled uuid string utf-8 field provided by Sea Of Stars
-    # For example, for "TitleScreen" you may see:
-    # this returns as example: 550e8400-e29b-41d4-a716-446655440000
-    # b'T\x00i\x00t\x00t\x00l\x00e\x00S\x00c\x00r\x00e\x00e\x00n'
-    # To "fix" this string, you will need to run value.replace("\x00", "")
     def read_uuid(self: Self, ptr: int) -> str:
         return pyMeow.bytes_to_string(self.pm, ptr, 37 * 2)
 
-    # Reads the garbled guid string utf-8 field provided by Sea Of Stars
-    # For example, for "TitleScreen" you may see:
-    # b'T\x00i\x00t\x00t\x00l\x00e\x00S\x00c\x00r\x00e\x00e\x00n'
-    # This returns as example: e6ac627711e4ee44da103c47d1cd5736
-    # To "fix" this string, you will need to run value.replace("\x00", "")
     def read_guid(self: Self, ptr: int) -> str:
         return pyMeow.bytes_to_string(self.pm, ptr, 64)
 
     def read_string(self: Self, ptr: int, length: int) -> str:
         return pyMeow.bytes_to_string(self.pm, ptr, length)
+
+    def read_raw_string(self: Self, ptr: int, length: int) -> str:
+        return pyMeow.r_string(self.pm, ptr, length)
 
     # Scans the module/image class list for a specific class name by string.
     def get_class(self: Self, class_name: str) -> int | None:

--- a/memory/core.py
+++ b/memory/core.py
@@ -1,5 +1,4 @@
 # Libraries and Core Files
-import codecs
 import logging
 import struct
 from typing import Self
@@ -125,7 +124,6 @@ class SoSMemory:
 
     def read_int(self: Self, ptr: int) -> int:
         return pyMeow.r_int(self.pm, ptr)
-
 
     def read_short(self: Self, address: int):
         bytes = pyMeow.r_bytes(self.pm, address, struct.calcsize("h"))

--- a/memory/core.py
+++ b/memory/core.py
@@ -136,11 +136,7 @@ class SoSMemory:
     # b'T\x00i\x00t\x00t\x00l\x00e\x00S\x00c\x00r\x00e\x00e\x00n'
     # To "fix" this string, you will need to run value.replace("\x00", "")
     def read_uuid(self: Self, ptr: int) -> str:
-        string = pyMeow.bytes_to_string(self.pm, ptr, 37 * 2)
-        print("UUID")
-        print(string)
-
-        return string
+        return pyMeow.bytes_to_string(self.pm, ptr, 37 * 2)
 
     # Reads the garbled guid string utf-8 field provided by Sea Of Stars
     # For example, for "TitleScreen" you may see:
@@ -148,14 +144,10 @@ class SoSMemory:
     # This returns as example: e6ac627711e4ee44da103c47d1cd5736
     # To "fix" this string, you will need to run value.replace("\x00", "")
     def read_guid(self: Self, ptr: int) -> str:
-        string = pyMeow.bytes_to_string(self.pm, ptr, 64)
-        print("GUID")
-        print(string)
-        return string
+        return pyMeow.bytes_to_string(self.pm, ptr, 64)
 
     def read_string(self: Self, ptr: int, length: int) -> str:
-        string = pyMeow.bytes_to_string(self.pm, ptr, length)
-        return string
+        return pyMeow.bytes_to_string(self.pm, ptr, length)
 
     # Scans the module/image class list for a specific class name by string.
     def get_class(self: Self, class_name: str) -> int | None:

--- a/memory/level_up_manager.py
+++ b/memory/level_up_manager.py
@@ -75,12 +75,12 @@ class LevelUpManager:
     def _read_current_character(self: Self) -> None:
         try:
             definition_id_ptr = self.memory.follow_pointer(
-                self.base, [0x88, 0x88, 0x50, 0x58, 0x40, 0x0]
+                self.base, [0x90, 0x88, 0x50, 0x58, 0x40, 0x0]
             )
             definition_id = self.memory.read_string(definition_id_ptr + 0x14, 8)
             # LevelUpSceneController -> currentCharacter -> stateMachine -> currentState...
             # -> player -> characterDefinitionId
-            definition_id_ptr = self.memory.follow_pointer(self.base, [0x88, 0x0])
+            definition_id_ptr = self.memory.follow_pointer(self.base, [0x90, 0x0])
             character = PlayerPartyCharacter.parse_definition_id(definition_id)
             self.current_character = character
         except Exception:
@@ -88,9 +88,9 @@ class LevelUpManager:
 
     def _read_current_level_up_upgrades(self: Self) -> None:
         # LevelUpSceneController -> currentLevelUpUpgrades -> _items -> item[x]
-        self.memory.follow_pointer(self.base, [0xB0, 0x0])
+        self.memory.follow_pointer(self.base, [0xB8, 0x0])
         try:
-            items = self.memory.follow_pointer(self.base, [0xB0, 0x10, 0x0])
+            items = self.memory.follow_pointer(self.base, [0xB8, 0x10, 0x0])
         except Exception:
             self.current_upgrades = []
             return

--- a/memory/mappers/player_party_character.py
+++ b/memory/mappers/player_party_character.py
@@ -17,18 +17,18 @@ class PlayerPartyCharacter(Enum):
     def parse_definition_id(definition_id: str) -> Self:
         ascii_data = definition_id.encode("ascii", "ignore")
 
-        if ascii_data == b"Z\x00A\x00L\x00E\x00":
+        if ascii_data == b"ZALE":
             return PlayerPartyCharacter.Zale
-        if ascii_data == b"V\x00A\x00L\x00E\x00":
+        if ascii_data == b"VALE":
             return PlayerPartyCharacter.Valere
-        if ascii_data == b"G\x00A\x00R\x00L\x00":
+        if ascii_data == b"GARL":
             return PlayerPartyCharacter.Garl
-        if ascii_data == b"S\x00E\x00R\x00A\x00":
+        if ascii_data == b"SERA":
             return PlayerPartyCharacter.Serai
-        if ascii_data == b"R\x00E\x00S\x00H\x00":
+        if ascii_data == b"RESH":
             return PlayerPartyCharacter.Reshan
-        if ascii_data == b"B\x00S\x00T\x00\x00\x00":
+        if ascii_data == b"BST":
             return PlayerPartyCharacter.Bst
-        if ascii_data == b"M\x00A\x00S\x00T\x00":
+        if ascii_data == b"MAST":
             return PlayerPartyCharacter.Moraine
         return PlayerPartyCharacter.NONE

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML >= 6.0.1
 pyMeow @ https://github.com/Eein/pyMeow/releases/download/sos-tas-1/pyMeow.zip
-glfw >= 2.6.2
-imgui-bundle >= 1.0.0
+glfw >= 2.7.0
+imgui-bundle >= 1.3.0
 vgamepad >= 0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML >= 6.0.1
-Pymem >= 1.13.0
+pyMeow @ https://github.com/Eein/pyMeow/releases/download/sos-tas-1/pyMeow.zip
 glfw >= 2.6.2
 imgui-bundle >= 1.0.0
 vgamepad >= 0.1.0

--- a/route/battle_test/battle_test.py
+++ b/route/battle_test/battle_test.py
@@ -1,6 +1,6 @@
 from typing import Self
 
-from engine.combat import SeqCombatAndMove
+from engine.combat import SeqCombat
 from engine.seq import (
     InteractMove,
     SeqBlackboard,
@@ -32,11 +32,8 @@ class BattleTestSequence(SeqList):
             name="Testing Fight",
             children=[
                 SeqBlackboard("Dash Strike", key="dash_strike", value=True),
-                SeqCombatAndMove(
-                    name="Fights",
-                    coords=[
-                        InteractMove(33.253, 6.002, 20.273),
-                    ],
+                SeqCombat(
+                    name="Battle Test",
                 ),
             ],
         )

--- a/route/battle_test/battle_test.py
+++ b/route/battle_test/battle_test.py
@@ -2,7 +2,6 @@ from typing import Self
 
 from engine.combat import SeqCombat
 from engine.seq import (
-    InteractMove,
     SeqBlackboard,
     SeqDelay,
     SeqList,


### PR DESCRIPTION
try running on non-beta version

the linter is probably going to be really upset - i'm working on getting ruff/black or whatever we use set up.

This PR adds 
- pyMeow with nim bindings for reading memory.. It should be about as fast as the old version but we get some nice things detailed here: https://github.com/qb-0/pyMeow/blob/master/cheatsheet.txt
- a flake.nix for nixOS people (me)
- a helper read_longlong and read_ulongong method, since pyMeow doesnt implement them directly.
- swaps to CheatEngine style aob scans provided in pymeow.
- inverts controls for linux
- fixes a few memory addresses that changed in recent patch.

The custom package in requirements removes the hard check for linux `sudo` the original package does; since we aren't doing writes we are totally fine, even if the package complains.

The windows bindings should work perfectly.

In the future, i may just include these bindings directly in the project instead of resolving them from a repository... but for now we'll go with this.

